### PR TITLE
[Feat] Implement recipient use cases

### DIFF
--- a/src/domain/cargo/application/repositories/orders-repository.ts
+++ b/src/domain/cargo/application/repositories/orders-repository.ts
@@ -1,0 +1,5 @@
+import { Order } from '../../enterprise/entities/order'
+
+export abstract class OrdersRepository {
+  abstract findById(id: string): Promise<Order | null>
+}

--- a/src/domain/cargo/application/repositories/recipients-repository.ts
+++ b/src/domain/cargo/application/repositories/recipients-repository.ts
@@ -1,0 +1,5 @@
+import { Recipient } from '../../enterprise/entities/recipient'
+
+export abstract class RecipientsRepository {
+  abstract create(recipient: Recipient): Promise<void>
+}

--- a/src/domain/cargo/application/repositories/recipients-repository.ts
+++ b/src/domain/cargo/application/repositories/recipients-repository.ts
@@ -4,4 +4,5 @@ export abstract class RecipientsRepository {
   abstract findById(id: string): Promise<Recipient | null>
   abstract create(recipient: Recipient): Promise<void>
   abstract save(recipient: Recipient): Promise<void>
+  abstract delete(recipient: Recipient): Promise<void>
 }

--- a/src/domain/cargo/application/repositories/recipients-repository.ts
+++ b/src/domain/cargo/application/repositories/recipients-repository.ts
@@ -3,4 +3,5 @@ import { Recipient } from '../../enterprise/entities/recipient'
 export abstract class RecipientsRepository {
   abstract findById(id: string): Promise<Recipient | null>
   abstract create(recipient: Recipient): Promise<void>
+  abstract save(recipient: Recipient): Promise<void>
 }

--- a/src/domain/cargo/application/repositories/recipients-repository.ts
+++ b/src/domain/cargo/application/repositories/recipients-repository.ts
@@ -1,7 +1,9 @@
+import { PaginationParams } from '@/core/repositories/pagination-params'
 import { Recipient } from '../../enterprise/entities/recipient'
 
 export abstract class RecipientsRepository {
   abstract findById(id: string): Promise<Recipient | null>
+  abstract findAll(params: PaginationParams): Promise<Recipient[]>
   abstract create(recipient: Recipient): Promise<void>
   abstract save(recipient: Recipient): Promise<void>
   abstract delete(recipient: Recipient): Promise<void>

--- a/src/domain/cargo/application/repositories/recipients-repository.ts
+++ b/src/domain/cargo/application/repositories/recipients-repository.ts
@@ -1,5 +1,6 @@
 import { Recipient } from '../../enterprise/entities/recipient'
 
 export abstract class RecipientsRepository {
+  abstract findById(id: string): Promise<Recipient | null>
   abstract create(recipient: Recipient): Promise<void>
 }

--- a/src/domain/cargo/application/use-cases/errors/not-allowed-error.ts
+++ b/src/domain/cargo/application/use-cases/errors/not-allowed-error.ts
@@ -1,0 +1,7 @@
+import { UseCaseError } from '@/core/errors/use-case-error'
+
+export class NotAllowedError extends Error implements UseCaseError {
+  constructor() {
+    super('Not allowed')
+  }
+}

--- a/src/domain/cargo/application/use-cases/recipient/add-recipient.spec.ts
+++ b/src/domain/cargo/application/use-cases/recipient/add-recipient.spec.ts
@@ -1,0 +1,63 @@
+import { AddRecipientUseCase } from './add-recipient'
+import { InMemoryRecipientRepository } from 'test/respositories/in-memory-recipients-repository'
+import { InMemoryOrdersRepository } from 'test/respositories/in-memory-orders-repository'
+import { makeRecipient } from 'test/factories/make-recipient'
+import { makeOrder } from 'test/factories/make-order'
+import { NotAllowedError } from '../errors/not-allowed-error'
+
+let inMemoryOrdersRepository: InMemoryOrdersRepository
+let inMemoryRecipientRepository: InMemoryRecipientRepository
+let sut: AddRecipientUseCase
+
+describe('Add Recipient', () => {
+  beforeEach(() => {
+    inMemoryOrdersRepository = new InMemoryOrdersRepository()
+    inMemoryRecipientRepository = new InMemoryRecipientRepository()
+
+    sut = new AddRecipientUseCase(
+      inMemoryOrdersRepository,
+      inMemoryRecipientRepository,
+    )
+  })
+
+  it('should be able to add a recipient', async () => {
+    const order = makeOrder()
+
+    inMemoryOrdersRepository.items.push(order)
+
+    const recipient = makeRecipient({
+      orderId: order.id,
+    })
+
+    const result = await sut.execute({
+      orderId: order.id.toString(),
+      name: recipient.name,
+      address: recipient.address,
+      role: 'ADMIN',
+    })
+
+    expect(result.isRight()).toBe(true)
+    expect(result.value?.recipient.name).toEqual(recipient.name)
+    expect(inMemoryRecipientRepository.items).toHaveLength(1)
+  })
+
+  it('should not be allowed to add a recipient if the user is not admin', async () => {
+    const order = makeOrder()
+
+    inMemoryOrdersRepository.items.push(order)
+
+    const recipient = makeRecipient({
+      orderId: order.id,
+    })
+
+    const result = await sut.execute({
+      orderId: order.id.toString(),
+      name: recipient.name,
+      address: recipient.address,
+      role: 'DELIVERY_DRIVER',
+    })
+
+    expect(result.isLeft()).toBe(true)
+    expect(result.value).toBeInstanceOf(NotAllowedError)
+  })
+})

--- a/src/domain/cargo/application/use-cases/recipient/add-recipient.ts
+++ b/src/domain/cargo/application/use-cases/recipient/add-recipient.ts
@@ -1,0 +1,66 @@
+import { Either, left, right } from '@/core/either'
+import { OrdersRepository } from '../../repositories/orders-repository'
+import { RecipientsRepository } from '../../repositories/recipients-repository'
+import { Recipient } from '@/domain/cargo/enterprise/entities/recipient'
+import { ResourceNotFoundError } from '../errors/resource-not-found-error'
+import { UniqueEntityID } from '@/core/entities/unique-entity-id'
+import { NotAllowedError } from '../errors/not-allowed-error'
+import { UserRole } from '@/domain/cargo/enterprise/entities/user-role'
+
+interface AddRecipientUseCaseRequest {
+  orderId: string
+  name: string
+  address: string
+  role: string
+}
+
+type AddRecipientUseCaseResponse = Either<
+  ResourceNotFoundError | NotAllowedError,
+  {
+    recipient: Recipient
+  }
+>
+
+export class AddRecipientUseCase {
+  constructor(
+    private ordersRepository: OrdersRepository,
+    private recipientRepository: RecipientsRepository,
+  ) {}
+
+  async execute({
+    orderId,
+    name,
+    address,
+    role,
+  }: AddRecipientUseCaseRequest): Promise<AddRecipientUseCaseResponse> {
+    const isValidRole = Object.values(UserRole).includes(role as UserRole)
+
+    if (!isValidRole) {
+      return left(new NotAllowedError())
+    }
+
+    const validRole = role as UserRole
+
+    if (validRole !== UserRole.ADMIN) {
+      return left(new NotAllowedError())
+    }
+
+    const order = await this.ordersRepository.findById(orderId)
+
+    if (!order) {
+      return left(new ResourceNotFoundError())
+    }
+
+    const recipient = Recipient.create({
+      orderId: new UniqueEntityID(orderId),
+      name,
+      address,
+    })
+
+    await this.recipientRepository.create(recipient)
+
+    return right({
+      recipient,
+    })
+  }
+}

--- a/src/domain/cargo/application/use-cases/recipient/delete-recipient.spec.ts
+++ b/src/domain/cargo/application/use-cases/recipient/delete-recipient.spec.ts
@@ -1,0 +1,33 @@
+import { UniqueEntityID } from '@/core/entities/unique-entity-id'
+import { InMemoryRecipientRepository } from 'test/respositories/in-memory-recipients-repository'
+import { DeleteRecipientUseCase } from './delete-recipient'
+import { makeRecipient } from 'test/factories/make-recipient'
+
+let inMemoryRecipientRepository: InMemoryRecipientRepository
+let sut: DeleteRecipientUseCase
+
+describe('Delete Recipient', () => {
+  beforeEach(() => {
+    inMemoryRecipientRepository = new InMemoryRecipientRepository()
+
+    sut = new DeleteRecipientUseCase(inMemoryRecipientRepository)
+  })
+
+  it('should be able to delete a recipient', async () => {
+    const recipient = makeRecipient(
+      {
+        name: 'John Doe',
+      },
+      new UniqueEntityID('driver-01'),
+    )
+
+    inMemoryRecipientRepository.create(recipient)
+
+    const result = await sut.execute({
+      recipientId: 'driver-01',
+    })
+
+    expect(result.isRight()).toBe(true)
+    expect(inMemoryRecipientRepository.items.length).toEqual(0)
+  })
+})

--- a/src/domain/cargo/application/use-cases/recipient/delete-recipient.spec.ts
+++ b/src/domain/cargo/application/use-cases/recipient/delete-recipient.spec.ts
@@ -2,6 +2,7 @@ import { UniqueEntityID } from '@/core/entities/unique-entity-id'
 import { InMemoryRecipientRepository } from 'test/respositories/in-memory-recipients-repository'
 import { DeleteRecipientUseCase } from './delete-recipient'
 import { makeRecipient } from 'test/factories/make-recipient'
+import { NotAllowedError } from '../errors/not-allowed-error'
 
 let inMemoryRecipientRepository: InMemoryRecipientRepository
 let sut: DeleteRecipientUseCase
@@ -25,9 +26,24 @@ describe('Delete Recipient', () => {
 
     const result = await sut.execute({
       recipientId: 'driver-01',
+      role: 'ADMIN',
     })
 
     expect(result.isRight()).toBe(true)
     expect(inMemoryRecipientRepository.items.length).toEqual(0)
+  })
+
+  it('should not be allowed to delete a recipient if the user is not admin', async () => {
+    const recipient = makeRecipient()
+
+    inMemoryRecipientRepository.create(recipient)
+
+    const result = await sut.execute({
+      recipientId: recipient.id.toString(),
+      role: 'DELIVER_DRIVER',
+    })
+
+    expect(result.isLeft()).toBe(true)
+    expect(result.value).toBeInstanceOf(NotAllowedError)
   })
 })

--- a/src/domain/cargo/application/use-cases/recipient/delete-recipient.ts
+++ b/src/domain/cargo/application/use-cases/recipient/delete-recipient.ts
@@ -1,0 +1,27 @@
+import { Either, left, right } from '@/core/either'
+import { ResourceNotFoundError } from '../errors/resource-not-found-error'
+import { RecipientsRepository } from '../../repositories/recipients-repository'
+
+interface DeleteRecipientUseCaseRequest {
+  recipientId: string
+}
+
+type DeleteRecipientUseCaseResponse = Either<ResourceNotFoundError, null>
+
+export class DeleteRecipientUseCase {
+  constructor(private recipientRepository: RecipientsRepository) {}
+
+  async execute({
+    recipientId,
+  }: DeleteRecipientUseCaseRequest): Promise<DeleteRecipientUseCaseResponse> {
+    const recipient = await this.recipientRepository.findById(recipientId)
+
+    if (!recipient) {
+      return left(new ResourceNotFoundError())
+    }
+
+    await this.recipientRepository.delete(recipient)
+
+    return right(null)
+  }
+}

--- a/src/domain/cargo/application/use-cases/recipient/delete-recipient.ts
+++ b/src/domain/cargo/application/use-cases/recipient/delete-recipient.ts
@@ -1,19 +1,38 @@
 import { Either, left, right } from '@/core/either'
 import { ResourceNotFoundError } from '../errors/resource-not-found-error'
 import { RecipientsRepository } from '../../repositories/recipients-repository'
+import { UserRole } from '@/domain/cargo/enterprise/entities/user-role'
+import { NotAllowedError } from '../errors/not-allowed-error'
 
 interface DeleteRecipientUseCaseRequest {
   recipientId: string
+  role: string
 }
 
-type DeleteRecipientUseCaseResponse = Either<ResourceNotFoundError, null>
+type DeleteRecipientUseCaseResponse = Either<
+  NotAllowedError | ResourceNotFoundError,
+  null
+>
 
 export class DeleteRecipientUseCase {
   constructor(private recipientRepository: RecipientsRepository) {}
 
   async execute({
     recipientId,
+    role,
   }: DeleteRecipientUseCaseRequest): Promise<DeleteRecipientUseCaseResponse> {
+    const isValidRole = Object.values(UserRole).includes(role as UserRole)
+
+    if (!isValidRole) {
+      return left(new NotAllowedError())
+    }
+
+    const validRole = role as UserRole
+
+    if (validRole !== UserRole.ADMIN) {
+      return left(new NotAllowedError())
+    }
+
     const recipient = await this.recipientRepository.findById(recipientId)
 
     if (!recipient) {

--- a/src/domain/cargo/application/use-cases/recipient/edit-recipient.spec.ts
+++ b/src/domain/cargo/application/use-cases/recipient/edit-recipient.spec.ts
@@ -1,6 +1,7 @@
 import { InMemoryRecipientRepository } from 'test/respositories/in-memory-recipients-repository'
 import { EditRecipientUseCase } from './edit-recipient'
 import { makeRecipient } from 'test/factories/make-recipient'
+import { NotAllowedError } from '../errors/not-allowed-error'
 
 let inMemoryRecipientRepository: InMemoryRecipientRepository
 let sut: EditRecipientUseCase
@@ -24,9 +25,29 @@ describe('Edit Recipient', () => {
       recipientId: recipient.id.toString(),
       name: 'John Doe',
       address: 'Edited address',
+      role: 'ADMIN',
     })
 
     expect(result.isRight()).toBe(true)
     expect(result.value?.recipient.address).toEqual('Edited address')
+  })
+
+  it('should not be allowed to edit a recipient if the user is not admin', async () => {
+    const recipient = makeRecipient({
+      name: 'John Doe',
+      address: 'Address 1',
+    })
+
+    inMemoryRecipientRepository.create(recipient)
+
+    const result = await sut.execute({
+      recipientId: recipient.id.toString(),
+      name: 'John Doe',
+      address: 'Edited address',
+      role: 'DELIVER_DRIVER',
+    })
+
+    expect(result.isLeft()).toBe(true)
+    expect(result.value).toBeInstanceOf(NotAllowedError)
   })
 })

--- a/src/domain/cargo/application/use-cases/recipient/edit-recipient.spec.ts
+++ b/src/domain/cargo/application/use-cases/recipient/edit-recipient.spec.ts
@@ -1,0 +1,32 @@
+import { InMemoryRecipientRepository } from 'test/respositories/in-memory-recipients-repository'
+import { EditRecipientUseCase } from './edit-recipient'
+import { makeRecipient } from 'test/factories/make-recipient'
+
+let inMemoryRecipientRepository: InMemoryRecipientRepository
+let sut: EditRecipientUseCase
+
+describe('Edit Recipient', () => {
+  beforeEach(() => {
+    inMemoryRecipientRepository = new InMemoryRecipientRepository()
+
+    sut = new EditRecipientUseCase(inMemoryRecipientRepository)
+  })
+
+  it('should be able to edit a recipient', async () => {
+    const recipient = makeRecipient({
+      name: 'John Doe',
+      address: 'Address 1',
+    })
+
+    inMemoryRecipientRepository.create(recipient)
+
+    const result = await sut.execute({
+      recipientId: recipient.id.toString(),
+      name: 'John Doe',
+      address: 'Edited address',
+    })
+
+    expect(result.isRight()).toBe(true)
+    expect(result.value?.recipient.address).toEqual('Edited address')
+  })
+})

--- a/src/domain/cargo/application/use-cases/recipient/edit-recipient.ts
+++ b/src/domain/cargo/application/use-cases/recipient/edit-recipient.ts
@@ -1,0 +1,42 @@
+import { Either, left, right } from '@/core/either'
+import { ResourceNotFoundError } from '../errors/resource-not-found-error'
+import { Recipient } from '@/domain/cargo/enterprise/entities/recipient'
+import { RecipientsRepository } from '../../repositories/recipients-repository'
+
+interface EditRecipientUseCaseRequest {
+  recipientId: string
+  name: string
+  address: string
+}
+
+type EditRecipientUseCaseResponse = Either<
+  ResourceNotFoundError,
+  {
+    recipient: Recipient
+  }
+>
+
+export class EditRecipientUseCase {
+  constructor(private recipientRepository: RecipientsRepository) {}
+
+  async execute({
+    recipientId,
+    name,
+    address,
+  }: EditRecipientUseCaseRequest): Promise<EditRecipientUseCaseResponse> {
+    const recipient = await this.recipientRepository.findById(recipientId)
+
+    if (!recipient) {
+      return left(new ResourceNotFoundError())
+    }
+
+    recipient.name = name
+    recipient.address = address
+
+    await this.recipientRepository.save(recipient)
+
+    return right({
+      recipient,
+    })
+  }
+}

--- a/src/domain/cargo/application/use-cases/recipient/fetch-recipients.spec.ts
+++ b/src/domain/cargo/application/use-cases/recipient/fetch-recipients.spec.ts
@@ -1,0 +1,39 @@
+import { InMemoryRecipientRepository } from 'test/respositories/in-memory-recipients-repository'
+import { FetchRecipientsUseCase } from './fetch-recipients'
+import { makeRecipient } from 'test/factories/make-recipient'
+
+let inMemoryRecipientRepository: InMemoryRecipientRepository
+let sut: FetchRecipientsUseCase
+
+describe('Fetch Recipients', () => {
+  beforeEach(() => {
+    inMemoryRecipientRepository = new InMemoryRecipientRepository()
+
+    sut = new FetchRecipientsUseCase(inMemoryRecipientRepository)
+  })
+
+  it('should be able to fetch recipients', async () => {
+    inMemoryRecipientRepository.create(makeRecipient())
+    inMemoryRecipientRepository.create(makeRecipient())
+
+    const result = await sut.execute({
+      page: 1,
+    })
+
+    expect(result.isRight()).toBe(true)
+    expect(result.value?.recipients).toHaveLength(2)
+  })
+
+  it('should be able to fetch paginated recipients', async () => {
+    for (let i = 0; i < 12; i++) {
+      inMemoryRecipientRepository.create(makeRecipient())
+    }
+
+    const result = await sut.execute({
+      page: 2,
+    })
+
+    expect(result.isRight()).toBe(true)
+    expect(result.value?.recipients).toHaveLength(2)
+  })
+})

--- a/src/domain/cargo/application/use-cases/recipient/fetch-recipients.ts
+++ b/src/domain/cargo/application/use-cases/recipient/fetch-recipients.ts
@@ -1,0 +1,30 @@
+import { Either, right } from '@/core/either'
+import { Recipient } from '@/domain/cargo/enterprise/entities/recipient'
+import { RecipientsRepository } from '../../repositories/recipients-repository'
+
+interface FetchRecipientsUseCaseRequest {
+  page: number
+}
+
+type FetchRecipientsUseCaseResponse = Either<
+  null,
+  {
+    recipients: Recipient[]
+  }
+>
+
+export class FetchRecipientsUseCase {
+  constructor(private recipientRepository: RecipientsRepository) {}
+
+  async execute({
+    page,
+  }: FetchRecipientsUseCaseRequest): Promise<FetchRecipientsUseCaseResponse> {
+    const recipients = await this.recipientRepository.findAll({
+      page,
+    })
+
+    return right({
+      recipients,
+    })
+  }
+}

--- a/src/domain/cargo/application/use-cases/recipient/get-recipient.spec.ts
+++ b/src/domain/cargo/application/use-cases/recipient/get-recipient.spec.ts
@@ -5,14 +5,14 @@ import { makeRecipient } from 'test/factories/make-recipient'
 let inMemoryRecipientRepository: InMemoryRecipientRepository
 let sut: GetRecipientUseCase
 
-describe('Get Delivery Driver', () => {
+describe('Get Recipient', () => {
   beforeEach(() => {
     inMemoryRecipientRepository = new InMemoryRecipientRepository()
 
     sut = new GetRecipientUseCase(inMemoryRecipientRepository)
   })
 
-  it('should be able to add a delivery driver', async () => {
+  it('should be able to add a recipient', async () => {
     const recipient = makeRecipient()
 
     inMemoryRecipientRepository.create(recipient)

--- a/src/domain/cargo/application/use-cases/recipient/get-recipient.spec.ts
+++ b/src/domain/cargo/application/use-cases/recipient/get-recipient.spec.ts
@@ -1,0 +1,27 @@
+import { InMemoryRecipientRepository } from 'test/respositories/in-memory-recipients-repository'
+import { GetRecipientUseCase } from './get-recipient'
+import { makeRecipient } from 'test/factories/make-recipient'
+
+let inMemoryRecipientRepository: InMemoryRecipientRepository
+let sut: GetRecipientUseCase
+
+describe('Get Delivery Driver', () => {
+  beforeEach(() => {
+    inMemoryRecipientRepository = new InMemoryRecipientRepository()
+
+    sut = new GetRecipientUseCase(inMemoryRecipientRepository)
+  })
+
+  it('should be able to add a delivery driver', async () => {
+    const recipient = makeRecipient()
+
+    inMemoryRecipientRepository.create(recipient)
+
+    const result = await sut.execute({
+      recipientId: recipient.id.toString(),
+    })
+
+    expect(result.isRight()).toBe(true)
+    expect(result.value?.recipient.name).toEqual(recipient.name)
+  })
+})

--- a/src/domain/cargo/application/use-cases/recipient/get-recipient.ts
+++ b/src/domain/cargo/application/use-cases/recipient/get-recipient.ts
@@ -1,0 +1,33 @@
+import { Either, left, right } from '@/core/either'
+import { ResourceNotFoundError } from '../errors/resource-not-found-error'
+import { Recipient } from '@/domain/cargo/enterprise/entities/recipient'
+import { RecipientsRepository } from '../../repositories/recipients-repository'
+
+interface GetRecipientUseCaseRequest {
+  recipientId: string
+}
+
+type GetRecipientUseCaseResponse = Either<
+  ResourceNotFoundError,
+  {
+    recipient: Recipient
+  }
+>
+
+export class GetRecipientUseCase {
+  constructor(private recipientRepository: RecipientsRepository) {}
+
+  async execute({
+    recipientId,
+  }: GetRecipientUseCaseRequest): Promise<GetRecipientUseCaseResponse> {
+    const recipient = await this.recipientRepository.findById(recipientId)
+
+    if (!recipient) {
+      return left(new ResourceNotFoundError())
+    }
+
+    return right({
+      recipient,
+    })
+  }
+}

--- a/src/domain/cargo/enterprise/entities/administrator.ts
+++ b/src/domain/cargo/enterprise/entities/administrator.ts
@@ -1,0 +1,57 @@
+import { Entity } from '@/core/entities/entity'
+import { UniqueEntityID } from '@/core/entities/unique-entity-id'
+import { UserRole } from './user-role'
+import { Optional } from '@/core/types/optional'
+
+export interface AdministratorProps {
+  orderId?: UniqueEntityID
+  taxId: string
+  name: string
+  password: string
+  role: UserRole
+}
+
+export class Administrator extends Entity<AdministratorProps> {
+  get orderId() {
+    return this.props.orderId
+  }
+
+  get taxId() {
+    return this.props.taxId
+  }
+
+  get name() {
+    return this.props.name
+  }
+
+  get password() {
+    return this.props.password
+  }
+
+  get role() {
+    return this.props.role
+  }
+
+  set name(name: string) {
+    this.props.name = name
+  }
+
+  set password(password: string) {
+    this.props.password = password
+  }
+
+  static create(
+    props: Optional<AdministratorProps, 'role'>,
+    id?: UniqueEntityID,
+  ) {
+    const deliverDriver = new Administrator(
+      {
+        ...props,
+        role: props.role ?? UserRole.ADMIN,
+      },
+      id,
+    )
+
+    return deliverDriver
+  }
+}

--- a/src/domain/cargo/enterprise/entities/delivery-driver.ts
+++ b/src/domain/cargo/enterprise/entities/delivery-driver.ts
@@ -1,11 +1,14 @@
 import { Entity } from '@/core/entities/entity'
 import { UniqueEntityID } from '@/core/entities/unique-entity-id'
+import { UserRole } from './user-role'
+import { Optional } from '@/core/types/optional'
 
 export interface DeliveryDriverProps {
   orderId?: UniqueEntityID
   taxId: string
   name: string
   password: string
+  role: UserRole
 }
 
 export class DeliveryDriver extends Entity<DeliveryDriverProps> {
@@ -25,6 +28,10 @@ export class DeliveryDriver extends Entity<DeliveryDriverProps> {
     return this.props.password
   }
 
+  get role() {
+    return this.props.role
+  }
+
   set name(name: string) {
     this.props.name = name
   }
@@ -33,8 +40,17 @@ export class DeliveryDriver extends Entity<DeliveryDriverProps> {
     this.props.password = password
   }
 
-  static create(props: DeliveryDriverProps, id?: UniqueEntityID) {
-    const deliverDriver = new DeliveryDriver(props, id)
+  static create(
+    props: Optional<DeliveryDriverProps, 'role'>,
+    id?: UniqueEntityID,
+  ) {
+    const deliverDriver = new DeliveryDriver(
+      {
+        ...props,
+        role: props.role ?? UserRole.DELIVERY_DRIVER,
+      },
+      id,
+    )
 
     return deliverDriver
   }

--- a/src/domain/cargo/enterprise/entities/recipient.ts
+++ b/src/domain/cargo/enterprise/entities/recipient.ts
@@ -1,12 +1,25 @@
-import { Entity } from '../../../../core/entities/entity'
-import { UniqueEntityID } from '../../../../core/entities/unique-entity-id'
+import { Entity } from '@/core/entities/entity'
+import { UniqueEntityID } from '@/core/entities/unique-entity-id'
 
 export interface RecipientProps {
   orderId: UniqueEntityID
   name: string
+  address: string
 }
 
 export class Recipient extends Entity<RecipientProps> {
+  get orderId() {
+    return this.props.orderId
+  }
+
+  get name() {
+    return this.props.name
+  }
+
+  get address() {
+    return this.props.address
+  }
+
   static create(props: RecipientProps, id?: UniqueEntityID) {
     const recipient = new Recipient(props, id)
 

--- a/src/domain/cargo/enterprise/entities/recipient.ts
+++ b/src/domain/cargo/enterprise/entities/recipient.ts
@@ -20,6 +20,14 @@ export class Recipient extends Entity<RecipientProps> {
     return this.props.address
   }
 
+  set name(name: string) {
+    this.props.name = name
+  }
+
+  set address(address: string) {
+    this.props.address = address
+  }
+
   static create(props: RecipientProps, id?: UniqueEntityID) {
     const recipient = new Recipient(props, id)
 

--- a/src/domain/cargo/enterprise/entities/user-role.ts
+++ b/src/domain/cargo/enterprise/entities/user-role.ts
@@ -1,0 +1,4 @@
+export enum UserRole {
+  ADMIN = 'ADMIN',
+  DELIVERY_DRIVER = 'DELIVERY_DRIVER',
+}

--- a/test/factories/make-order.ts
+++ b/test/factories/make-order.ts
@@ -1,0 +1,23 @@
+import { UniqueEntityID } from '@/core/entities/unique-entity-id'
+import {
+  Order,
+  OrderProps,
+  OrderStatus,
+} from '@/domain/cargo/enterprise/entities/order'
+
+export function makeOrder(
+  override: Partial<OrderProps> = {},
+  id?: UniqueEntityID,
+) {
+  const deliverDriver = Order.create(
+    {
+      deliveryDriverId: new UniqueEntityID(),
+      recipientId: new UniqueEntityID(),
+      status: OrderStatus.WAITING,
+      ...override,
+    },
+    id,
+  )
+
+  return deliverDriver
+}

--- a/test/factories/make-recipient.ts
+++ b/test/factories/make-recipient.ts
@@ -1,0 +1,23 @@
+import { UniqueEntityID } from '@/core/entities/unique-entity-id'
+import {
+  Recipient,
+  RecipientProps,
+} from '@/domain/cargo/enterprise/entities/recipient'
+import { faker } from '@faker-js/faker'
+
+export function makeRecipient(
+  override: Partial<RecipientProps> = {},
+  id?: UniqueEntityID,
+) {
+  const deliverDriver = Recipient.create(
+    {
+      orderId: new UniqueEntityID(),
+      name: faker.person.fullName(),
+      address: faker.location.streetAddress(),
+      ...override,
+    },
+    id,
+  )
+
+  return deliverDriver
+}

--- a/test/respositories/in-memory-orders-repository.ts
+++ b/test/respositories/in-memory-orders-repository.ts
@@ -1,0 +1,16 @@
+import { OrdersRepository } from '@/domain/cargo/application/repositories/orders-repository'
+import { Order } from '@/domain/cargo/enterprise/entities/order'
+
+export class InMemoryOrdersRepository extends OrdersRepository {
+  public items: Order[] = []
+
+  async findById(id: string): Promise<Order | null> {
+    const order = this.items.find((item) => item.id.toString() === id)
+
+    if (!order) {
+      return null
+    }
+
+    return order
+  }
+}

--- a/test/respositories/in-memory-recipients-repository.ts
+++ b/test/respositories/in-memory-recipients-repository.ts
@@ -17,4 +17,10 @@ export class InMemoryRecipientRepository extends RecipientsRepository {
   async create(recipient: Recipient) {
     this.items.push(recipient)
   }
+
+  async save(recipient: Recipient) {
+    const itemIndex = this.items.findIndex((item) => item.id === recipient.id)
+
+    this.items[itemIndex] = recipient
+  }
 }

--- a/test/respositories/in-memory-recipients-repository.ts
+++ b/test/respositories/in-memory-recipients-repository.ts
@@ -4,7 +4,17 @@ import { Recipient } from '@/domain/cargo/enterprise/entities/recipient'
 export class InMemoryRecipientRepository extends RecipientsRepository {
   public items: Recipient[] = []
 
-  async create(deliverDriver: Recipient) {
-    this.items.push(deliverDriver)
+  async findById(id: string) {
+    const recipient = this.items.find((item) => item.id.toString() === id)
+
+    if (!recipient) {
+      return null
+    }
+
+    return recipient
+  }
+
+  async create(recipient: Recipient) {
+    this.items.push(recipient)
   }
 }

--- a/test/respositories/in-memory-recipients-repository.ts
+++ b/test/respositories/in-memory-recipients-repository.ts
@@ -1,3 +1,4 @@
+import { PaginationParams } from '@/core/repositories/pagination-params'
 import { RecipientsRepository } from '@/domain/cargo/application/repositories/recipients-repository'
 import { Recipient } from '@/domain/cargo/enterprise/entities/recipient'
 
@@ -12,6 +13,12 @@ export class InMemoryRecipientRepository extends RecipientsRepository {
     }
 
     return recipient
+  }
+
+  async findAll({ page }: PaginationParams) {
+    const recipients = this.items.slice((page - 1) * 10, page * 10)
+
+    return recipients
   }
 
   async create(recipient: Recipient) {

--- a/test/respositories/in-memory-recipients-repository.ts
+++ b/test/respositories/in-memory-recipients-repository.ts
@@ -23,4 +23,10 @@ export class InMemoryRecipientRepository extends RecipientsRepository {
 
     this.items[itemIndex] = recipient
   }
+
+  async delete(recipient: Recipient): Promise<void> {
+    const itemIndex = this.items.findIndex((item) => item.id === recipient.id)
+
+    this.items.splice(itemIndex, 1)
+  }
 }

--- a/test/respositories/in-memory-recipients-repository.ts
+++ b/test/respositories/in-memory-recipients-repository.ts
@@ -1,0 +1,10 @@
+import { RecipientsRepository } from '@/domain/cargo/application/repositories/recipients-repository'
+import { Recipient } from '@/domain/cargo/enterprise/entities/recipient'
+
+export class InMemoryRecipientRepository extends RecipientsRepository {
+  public items: Recipient[] = []
+
+  async create(deliverDriver: Recipient) {
+    this.items.push(deliverDriver)
+  }
+}


### PR DESCRIPTION
## Description

<!-- Write a short summary of what this PR does -->
This PR adds Recipient use cases with CRUD operations

## Main changes

- <!-- List key technical changes made -->
- Created `Administrator` entity
- Added `UserRole` to `Administrator` and `DeliveryDriver`
- Created `OrdersRepository`
- Created `RecipientsRepository` 
- Implemented `AddRecipient` use case
- Implemented `GetRecipient` use case
- Implemented `FetchRecipients` use case
- Implemented `EditRecipient` use case
- Implemented `DeleteRecipient` use case 

## Motivation

<!-- Explain why this change was needed -->
These changes provide recipient manipulation inside the application on the domain layer.

## How to test

1. Run unit test `npm run test`
2. Ensure that all tests pass

## Related issues

Closes #10