### PR TITLE
[Fix] Add user role validation to delivery driver use cases

### DIFF
--- a/src/domain/cargo/application/use-cases/delivery-driver/delete-delivery-driver.spec.ts
+++ b/src/domain/cargo/application/use-cases/delivery-driver/delete-delivery-driver.spec.ts
@@ -2,6 +2,8 @@ import { InMemoryDeliveryDriverRepository } from 'test/respositories/in-memory-d
 import { makeDeliveryDriver } from 'test/factories/make-delivery-driver'
 import { DeleteDeliveryDriverUseCase } from './delete-delivery-driver'
 import { UniqueEntityID } from '@/core/entities/unique-entity-id'
+import { makeAdministrator } from 'test/factories/make-administrator'
+import { NotAllowedError } from '../errors/not-allowed-error'
 
 let inMemoryDeliveryDriverRepository: InMemoryDeliveryDriverRepository
 let sut: DeleteDeliveryDriverUseCase
@@ -24,11 +26,34 @@ describe('Delete Delivery Driver', () => {
 
     inMemoryDeliveryDriverRepository.create(deliveryDriver)
 
+    const administrator = makeAdministrator()
+
     const result = await sut.execute({
       deliveryDriverId: 'driver-01',
+      role: administrator.role,
     })
 
     expect(result.isRight()).toBe(true)
     expect(inMemoryDeliveryDriverRepository.items.length).toEqual(0)
+  })
+
+  it('should not be able to delete a delivery driver if the user is not an administrator', async () => {
+    const deliveryDriver = makeDeliveryDriver(
+      {
+        name: 'John Doe',
+        password: '123456',
+      },
+      new UniqueEntityID('driver-01'),
+    )
+
+    inMemoryDeliveryDriverRepository.create(deliveryDriver)
+
+    const result = await sut.execute({
+      deliveryDriverId: 'driver-01',
+      role: deliveryDriver.role,
+    })
+
+    expect(result.isLeft()).toBe(true)
+    expect(result.value).toBeInstanceOf(NotAllowedError)
   })
 })

--- a/src/domain/cargo/application/use-cases/delivery-driver/delete-delivery-driver.ts
+++ b/src/domain/cargo/application/use-cases/delivery-driver/delete-delivery-driver.ts
@@ -1,9 +1,12 @@
 import { Either, left, right } from '@/core/either'
 import { DeliveryDriverRepository } from '../../repositories/delivery-driver-repository'
 import { ResourceNotFoundError } from '../errors/resource-not-found-error'
+import { UserRole } from '@/domain/cargo/enterprise/entities/user-role'
+import { NotAllowedError } from '../errors/not-allowed-error'
 
 interface DeleteDeliveryDriverUseCaseRequest {
   deliveryDriverId: string
+  role: string
 }
 
 type DeleteDeliveryDriverUseCaseResponse = Either<ResourceNotFoundError, null>
@@ -13,7 +16,20 @@ export class DeleteDeliveryDriverUseCase {
 
   async execute({
     deliveryDriverId,
+    role,
   }: DeleteDeliveryDriverUseCaseRequest): Promise<DeleteDeliveryDriverUseCaseResponse> {
+    const isValidRole = Object.values(UserRole).includes(role as UserRole)
+
+    if (!isValidRole) {
+      return left(new NotAllowedError())
+    }
+
+    const validRole = role as UserRole
+
+    if (validRole !== UserRole.ADMIN) {
+      return left(new NotAllowedError())
+    }
+
     const deliveryDriver =
       await this.deliveryDriverRepository.findById(deliveryDriverId)
 

--- a/src/domain/cargo/application/use-cases/delivery-driver/edit-delivery-driver.spec.ts
+++ b/src/domain/cargo/application/use-cases/delivery-driver/edit-delivery-driver.spec.ts
@@ -1,6 +1,8 @@
 import { InMemoryDeliveryDriverRepository } from 'test/respositories/in-memory-delivery-driver-repository'
 import { makeDeliveryDriver } from 'test/factories/make-delivery-driver'
 import { EditDeliveryDriverUseCase } from './edit-delivery-driver'
+import { makeAdministrator } from 'test/factories/make-administrator'
+import { NotAllowedError } from '../errors/not-allowed-error'
 
 let inMemoryDeliveryDriverRepository: InMemoryDeliveryDriverRepository
 let sut: EditDeliveryDriverUseCase
@@ -18,15 +20,37 @@ describe('Edit Delivery Driver', () => {
       password: '123456',
     })
 
+    const administrator = makeAdministrator()
+
     inMemoryDeliveryDriverRepository.create(deliveryDriver)
 
     const result = await sut.execute({
       deliveryDriverId: deliveryDriver.id.toString(),
       name: 'John Doe',
       password: '123123',
+      role: administrator.role,
     })
 
     expect(result.isRight()).toBe(true)
     expect(result.value?.deliveryDriver.password).toEqual('123123')
+  })
+
+  it('should not be able to edit a delivery driver if the use is not an administrator', async () => {
+    const deliveryDriver = makeDeliveryDriver({
+      name: 'John Doe',
+      password: '123456',
+    })
+
+    inMemoryDeliveryDriverRepository.create(deliveryDriver)
+
+    const result = await sut.execute({
+      deliveryDriverId: deliveryDriver.id.toString(),
+      name: 'John Doe',
+      password: '123123',
+      role: deliveryDriver.role,
+    })
+
+    expect(result.isLeft()).toBe(true)
+    expect(result.value).toBeInstanceOf(NotAllowedError)
   })
 })

--- a/src/domain/cargo/application/use-cases/delivery-driver/edit-delivery-driver.ts
+++ b/src/domain/cargo/application/use-cases/delivery-driver/edit-delivery-driver.ts
@@ -2,15 +2,18 @@ import { Either, left, right } from '@/core/either'
 import { DeliveryDriver } from '@/domain/cargo/enterprise/entities/delivery-driver'
 import { DeliveryDriverRepository } from '../../repositories/delivery-driver-repository'
 import { ResourceNotFoundError } from '../errors/resource-not-found-error'
+import { UserRole } from '@/domain/cargo/enterprise/entities/user-role'
+import { NotAllowedError } from '../errors/not-allowed-error'
 
 interface EditDeliveryDriverUseCaseRequest {
   deliveryDriverId: string
   name: string
   password: string
+  role: string
 }
 
 type EditDeliveryDriverUseCaseResponse = Either<
-  ResourceNotFoundError,
+  NotAllowedError | ResourceNotFoundError,
   {
     deliveryDriver: DeliveryDriver
   }
@@ -23,7 +26,20 @@ export class EditDeliveryDriverUseCase {
     deliveryDriverId,
     name,
     password,
+    role,
   }: EditDeliveryDriverUseCaseRequest): Promise<EditDeliveryDriverUseCaseResponse> {
+    const isValidRole = Object.values(UserRole).includes(role as UserRole)
+
+    if (!isValidRole) {
+      return left(new NotAllowedError())
+    }
+
+    const validRole = role as UserRole
+
+    if (validRole !== UserRole.ADMIN) {
+      return left(new NotAllowedError())
+    }
+
     const deliveryDriver =
       await this.deliveryDriverRepository.findById(deliveryDriverId)
 

--- a/test/factories/make-administrator.ts
+++ b/test/factories/make-administrator.ts
@@ -1,0 +1,23 @@
+import { UniqueEntityID } from '@/core/entities/unique-entity-id'
+import {
+  Administrator,
+  AdministratorProps,
+} from '@/domain/cargo/enterprise/entities/administrator'
+import { faker } from '@faker-js/faker'
+
+export function makeAdministrator(
+  override: Partial<AdministratorProps> = {},
+  id?: UniqueEntityID,
+) {
+  const administrator = Administrator.create(
+    {
+      taxId: faker.string.numeric(),
+      name: faker.person.fullName(),
+      password: faker.internet.password(),
+      ...override,
+    },
+    id,
+  )
+
+  return administrator
+}


### PR DESCRIPTION
## Description

<!-- Write a short summary of what this PR does -->
This PR adds user role validation to delivery driver use cases

## Main changes

- <!-- List key technical changes made -->
- Added user role validation to `AddDeliveryDriverUseCase`
- Added user role validation to `EditDeliveryDriverUseCase`
- Added user role validation to `DeleteDeliveryDriverUseCase`
- Updated unit tests

## Motivation

<!-- Explain why this change was needed -->
These changes prevent users that is not administrators from doing CRUD operations on the Delivery Driver

## How to test

1. Run unit test `npm run test`
2. Ensure that all tests pass

## Related issues

Closes #12 