### PR TITLE
[Feat] Implement order use cases

### DIFF
--- a/src/domain/cargo/application/repositories/orders-repository.ts
+++ b/src/domain/cargo/application/repositories/orders-repository.ts
@@ -2,4 +2,5 @@ import { Order } from '../../enterprise/entities/order'
 
 export abstract class OrdersRepository {
   abstract findById(id: string): Promise<Order | null>
+  abstract create(order: Order): Promise<void>
 }

--- a/src/domain/cargo/application/repositories/orders-repository.ts
+++ b/src/domain/cargo/application/repositories/orders-repository.ts
@@ -3,4 +3,5 @@ import { Order } from '../../enterprise/entities/order'
 export abstract class OrdersRepository {
   abstract findById(id: string): Promise<Order | null>
   abstract create(order: Order): Promise<void>
+  abstract delete(order: Order): Promise<void>
 }

--- a/src/domain/cargo/application/use-cases/order/create-order.spec.ts
+++ b/src/domain/cargo/application/use-cases/order/create-order.spec.ts
@@ -1,0 +1,49 @@
+import { InMemoryRecipientRepository } from 'test/respositories/in-memory-recipients-repository'
+import { InMemoryOrdersRepository } from 'test/respositories/in-memory-orders-repository'
+import { makeRecipient } from 'test/factories/make-recipient'
+import { NotAllowedError } from '../errors/not-allowed-error'
+import { CreateOrderUseCase } from './create-order'
+
+let inMemoryOrdersRepository: InMemoryOrdersRepository
+let inMemoryRecipientRepository: InMemoryRecipientRepository
+let sut: CreateOrderUseCase
+
+describe('Create Order', () => {
+  beforeEach(() => {
+    inMemoryOrdersRepository = new InMemoryOrdersRepository()
+    inMemoryRecipientRepository = new InMemoryRecipientRepository()
+
+    sut = new CreateOrderUseCase(
+      inMemoryOrdersRepository,
+      inMemoryRecipientRepository,
+    )
+  })
+
+  it('should be able to create an order', async () => {
+    const recipient = makeRecipient()
+
+    inMemoryRecipientRepository.items.push(recipient)
+
+    const result = await sut.execute({
+      recipientId: recipient.id.toString(),
+      role: 'ADMIN',
+    })
+
+    expect(result.isRight()).toBe(true)
+    expect(inMemoryOrdersRepository.items).toHaveLength(1)
+  })
+
+  it('should not be allowed to create an order if the user is not admin', async () => {
+    const recipient = makeRecipient()
+
+    inMemoryRecipientRepository.items.push(recipient)
+
+    const result = await sut.execute({
+      recipientId: recipient.id.toString(),
+      role: 'DELIVERY_DRIVER',
+    })
+
+    expect(result.isLeft()).toBe(true)
+    expect(result.value).toBeInstanceOf(NotAllowedError)
+  })
+})

--- a/src/domain/cargo/application/use-cases/order/create-order.ts
+++ b/src/domain/cargo/application/use-cases/order/create-order.ts
@@ -1,0 +1,60 @@
+import { Either, left, right } from '@/core/either'
+import { OrdersRepository } from '../../repositories/orders-repository'
+import { RecipientsRepository } from '../../repositories/recipients-repository'
+import { ResourceNotFoundError } from '../errors/resource-not-found-error'
+import { UniqueEntityID } from '@/core/entities/unique-entity-id'
+import { NotAllowedError } from '../errors/not-allowed-error'
+import { UserRole } from '@/domain/cargo/enterprise/entities/user-role'
+import { Order } from '@/domain/cargo/enterprise/entities/order'
+
+interface CreateOrderUseCaseRequest {
+  recipientId: string
+  role: string
+}
+
+type CreateOrderUseCaseResponse = Either<
+  ResourceNotFoundError | NotAllowedError,
+  {
+    order: Order
+  }
+>
+
+export class CreateOrderUseCase {
+  constructor(
+    private ordersRepository: OrdersRepository,
+    private recipientRepository: RecipientsRepository,
+  ) {}
+
+  async execute({
+    recipientId,
+    role,
+  }: CreateOrderUseCaseRequest): Promise<CreateOrderUseCaseResponse> {
+    const isValidRole = Object.values(UserRole).includes(role as UserRole)
+
+    if (!isValidRole) {
+      return left(new NotAllowedError())
+    }
+
+    const validRole = role as UserRole
+
+    if (validRole !== UserRole.ADMIN) {
+      return left(new NotAllowedError())
+    }
+
+    const recipient = await this.recipientRepository.findById(recipientId)
+
+    if (!recipient) {
+      return left(new ResourceNotFoundError())
+    }
+
+    const order = Order.create({
+      recipientId: new UniqueEntityID(recipientId),
+    })
+
+    await this.ordersRepository.create(order)
+
+    return right({
+      order,
+    })
+  }
+}

--- a/src/domain/cargo/application/use-cases/order/delete-order.spec.ts
+++ b/src/domain/cargo/application/use-cases/order/delete-order.spec.ts
@@ -1,0 +1,43 @@
+import { DeleteOrderUseCase } from './delete-order'
+import { makeOrder } from 'test/factories/make-order'
+import { NotAllowedError } from '../errors/not-allowed-error'
+import { InMemoryOrdersRepository } from 'test/respositories/in-memory-orders-repository'
+
+let inMemoryOrdersRepository: InMemoryOrdersRepository
+let sut: DeleteOrderUseCase
+
+describe('Delete Order', () => {
+  beforeEach(() => {
+    inMemoryOrdersRepository = new InMemoryOrdersRepository()
+
+    sut = new DeleteOrderUseCase(inMemoryOrdersRepository)
+  })
+
+  it('should be able to delete an order', async () => {
+    const order = makeOrder()
+
+    inMemoryOrdersRepository.create(order)
+
+    const result = await sut.execute({
+      orderId: order.id.toString(),
+      role: 'ADMIN',
+    })
+
+    expect(result.isRight()).toBe(true)
+    expect(inMemoryOrdersRepository.items.length).toEqual(0)
+  })
+
+  it('should not be allowed to delete an order if the user is not admin', async () => {
+    const order = makeOrder()
+
+    inMemoryOrdersRepository.create(order)
+
+    const result = await sut.execute({
+      orderId: order.id.toString(),
+      role: 'DELIVER_DRIVER',
+    })
+
+    expect(result.isLeft()).toBe(true)
+    expect(result.value).toBeInstanceOf(NotAllowedError)
+  })
+})

--- a/src/domain/cargo/application/use-cases/order/delete-order.ts
+++ b/src/domain/cargo/application/use-cases/order/delete-order.ts
@@ -1,0 +1,46 @@
+import { Either, left, right } from '@/core/either'
+import { ResourceNotFoundError } from '../errors/resource-not-found-error'
+import { OrdersRepository } from '../../repositories/orders-repository'
+import { UserRole } from '@/domain/cargo/enterprise/entities/user-role'
+import { NotAllowedError } from '../errors/not-allowed-error'
+
+interface DeleteOrderUseCaseRequest {
+  orderId: string
+  role: string
+}
+
+type DeleteOrderUseCaseResponse = Either<
+  NotAllowedError | ResourceNotFoundError,
+  null
+>
+
+export class DeleteOrderUseCase {
+  constructor(private ordersRepository: OrdersRepository) {}
+
+  async execute({
+    orderId,
+    role,
+  }: DeleteOrderUseCaseRequest): Promise<DeleteOrderUseCaseResponse> {
+    const isValidRole = Object.values(UserRole).includes(role as UserRole)
+
+    if (!isValidRole) {
+      return left(new NotAllowedError())
+    }
+
+    const validRole = role as UserRole
+
+    if (validRole !== UserRole.ADMIN) {
+      return left(new NotAllowedError())
+    }
+
+    const order = await this.ordersRepository.findById(orderId)
+
+    if (!order) {
+      return left(new ResourceNotFoundError())
+    }
+
+    await this.ordersRepository.delete(order)
+
+    return right(null)
+  }
+}

--- a/src/domain/cargo/application/use-cases/order/get-order.spec.ts
+++ b/src/domain/cargo/application/use-cases/order/get-order.spec.ts
@@ -1,0 +1,27 @@
+import { InMemoryOrdersRepository } from 'test/respositories/in-memory-orders-repository'
+import { GetOrderUseCase } from './get-order'
+import { makeOrder } from 'test/factories/make-order'
+
+let inMemoryOrdersRepository: InMemoryOrdersRepository
+let sut: GetOrderUseCase
+
+describe('Get Order', () => {
+  beforeEach(() => {
+    inMemoryOrdersRepository = new InMemoryOrdersRepository()
+
+    sut = new GetOrderUseCase(inMemoryOrdersRepository)
+  })
+
+  it('should be able to add a order', async () => {
+    const order = makeOrder()
+
+    inMemoryOrdersRepository.create(order)
+
+    const result = await sut.execute({
+      orderId: order.id.toString(),
+    })
+
+    expect(result.isRight()).toBe(true)
+    expect(result.value?.order.id).toEqual(order.id)
+  })
+})

--- a/src/domain/cargo/application/use-cases/order/get-order.ts
+++ b/src/domain/cargo/application/use-cases/order/get-order.ts
@@ -1,0 +1,33 @@
+import { Either, left, right } from '@/core/either'
+import { ResourceNotFoundError } from '../errors/resource-not-found-error'
+import { Order } from '@/domain/cargo/enterprise/entities/order'
+import { OrdersRepository } from '../../repositories/orders-repository'
+
+interface GetOrderUseCaseRequest {
+  orderId: string
+}
+
+type GetOrderUseCaseResponse = Either<
+  ResourceNotFoundError,
+  {
+    order: Order
+  }
+>
+
+export class GetOrderUseCase {
+  constructor(private ordersRepository: OrdersRepository) {}
+
+  async execute({
+    orderId,
+  }: GetOrderUseCaseRequest): Promise<GetOrderUseCaseResponse> {
+    const order = await this.ordersRepository.findById(orderId)
+
+    if (!order) {
+      return left(new ResourceNotFoundError())
+    }
+
+    return right({
+      order,
+    })
+  }
+}

--- a/src/domain/cargo/application/use-cases/recipient/add-recipient.spec.ts
+++ b/src/domain/cargo/application/use-cases/recipient/add-recipient.spec.ts
@@ -1,36 +1,22 @@
 import { AddRecipientUseCase } from './add-recipient'
 import { InMemoryRecipientRepository } from 'test/respositories/in-memory-recipients-repository'
-import { InMemoryOrdersRepository } from 'test/respositories/in-memory-orders-repository'
 import { makeRecipient } from 'test/factories/make-recipient'
-import { makeOrder } from 'test/factories/make-order'
 import { NotAllowedError } from '../errors/not-allowed-error'
 
-let inMemoryOrdersRepository: InMemoryOrdersRepository
 let inMemoryRecipientRepository: InMemoryRecipientRepository
 let sut: AddRecipientUseCase
 
 describe('Add Recipient', () => {
   beforeEach(() => {
-    inMemoryOrdersRepository = new InMemoryOrdersRepository()
     inMemoryRecipientRepository = new InMemoryRecipientRepository()
 
-    sut = new AddRecipientUseCase(
-      inMemoryOrdersRepository,
-      inMemoryRecipientRepository,
-    )
+    sut = new AddRecipientUseCase(inMemoryRecipientRepository)
   })
 
   it('should be able to add a recipient', async () => {
-    const order = makeOrder()
-
-    inMemoryOrdersRepository.items.push(order)
-
-    const recipient = makeRecipient({
-      orderId: order.id,
-    })
+    const recipient = makeRecipient()
 
     const result = await sut.execute({
-      orderId: order.id.toString(),
       name: recipient.name,
       address: recipient.address,
       role: 'ADMIN',
@@ -42,16 +28,9 @@ describe('Add Recipient', () => {
   })
 
   it('should not be allowed to add a recipient if the user is not admin', async () => {
-    const order = makeOrder()
-
-    inMemoryOrdersRepository.items.push(order)
-
-    const recipient = makeRecipient({
-      orderId: order.id,
-    })
+    const recipient = makeRecipient()
 
     const result = await sut.execute({
-      orderId: order.id.toString(),
       name: recipient.name,
       address: recipient.address,
       role: 'DELIVERY_DRIVER',

--- a/src/domain/cargo/application/use-cases/recipient/add-recipient.ts
+++ b/src/domain/cargo/application/use-cases/recipient/add-recipient.ts
@@ -1,14 +1,11 @@
 import { Either, left, right } from '@/core/either'
-import { OrdersRepository } from '../../repositories/orders-repository'
 import { RecipientsRepository } from '../../repositories/recipients-repository'
 import { Recipient } from '@/domain/cargo/enterprise/entities/recipient'
 import { ResourceNotFoundError } from '../errors/resource-not-found-error'
-import { UniqueEntityID } from '@/core/entities/unique-entity-id'
 import { NotAllowedError } from '../errors/not-allowed-error'
 import { UserRole } from '@/domain/cargo/enterprise/entities/user-role'
 
 interface AddRecipientUseCaseRequest {
-  orderId: string
   name: string
   address: string
   role: string
@@ -22,13 +19,9 @@ type AddRecipientUseCaseResponse = Either<
 >
 
 export class AddRecipientUseCase {
-  constructor(
-    private ordersRepository: OrdersRepository,
-    private recipientRepository: RecipientsRepository,
-  ) {}
+  constructor(private recipientRepository: RecipientsRepository) {}
 
   async execute({
-    orderId,
     name,
     address,
     role,
@@ -45,14 +38,7 @@ export class AddRecipientUseCase {
       return left(new NotAllowedError())
     }
 
-    const order = await this.ordersRepository.findById(orderId)
-
-    if (!order) {
-      return left(new ResourceNotFoundError())
-    }
-
     const recipient = Recipient.create({
-      orderId: new UniqueEntityID(orderId),
       name,
       address,
     })

--- a/src/domain/cargo/enterprise/entities/order.ts
+++ b/src/domain/cargo/enterprise/entities/order.ts
@@ -1,6 +1,6 @@
-import { Entity } from '../../../../core/entities/entity'
 import { UniqueEntityID } from '../../../../core/entities/unique-entity-id'
 import { Optional } from '../../../../core/types/optional'
+import { Entity } from '@/core/entities/entity'
 
 export enum OrderStatus {
   WAITING = 'WAITING',
@@ -10,18 +10,22 @@ export enum OrderStatus {
 }
 
 export interface OrderProps {
-  deliveryDriverId: UniqueEntityID
+  deliveryDriverId?: UniqueEntityID
   recipientId: UniqueEntityID
-  status: OrderStatus
+  status?: OrderStatus
   createdAt: Date
   updatedAt?: Date
 }
 
 export class Order extends Entity<OrderProps> {
-  static create(props: Optional<OrderProps, 'createdAt'>, id?: UniqueEntityID) {
+  static create(
+    props: Optional<OrderProps, 'status' | 'createdAt'>,
+    id?: UniqueEntityID,
+  ) {
     const order = new Order(
       {
         ...props,
+        status: props.status ?? OrderStatus.WAITING,
         createdAt: props.createdAt ?? new Date(),
       },
       id,

--- a/src/domain/cargo/enterprise/entities/recipient.ts
+++ b/src/domain/cargo/enterprise/entities/recipient.ts
@@ -2,7 +2,7 @@ import { Entity } from '@/core/entities/entity'
 import { UniqueEntityID } from '@/core/entities/unique-entity-id'
 
 export interface RecipientProps {
-  orderId: UniqueEntityID
+  orderId?: UniqueEntityID
   name: string
   address: string
 }

--- a/test/respositories/in-memory-orders-repository.ts
+++ b/test/respositories/in-memory-orders-repository.ts
@@ -13,4 +13,8 @@ export class InMemoryOrdersRepository extends OrdersRepository {
 
     return order
   }
+
+  async create(order: Order): Promise<void> {
+    this.items.push(order)
+  }
 }

--- a/test/respositories/in-memory-orders-repository.ts
+++ b/test/respositories/in-memory-orders-repository.ts
@@ -17,4 +17,10 @@ export class InMemoryOrdersRepository extends OrdersRepository {
   async create(order: Order): Promise<void> {
     this.items.push(order)
   }
+
+  async delete(order: Order): Promise<void> {
+    const itemIndex = this.items.findIndex((item) => item.id === order.id)
+
+    this.items.splice(itemIndex, 1)
+  }
 }


### PR DESCRIPTION
## Description

<!-- Write a short summary of what this PR does -->
This PR adds Order use cases with CRUD operations

## Main changes

- Created `Orders` repository
- Updated `Order` with optional status on entity creation
- Implemented `CreateOrder` use case
- Implemented `GetOrder` use case 
- Implemented `DeleteOrder` use case
- Removed `orderId` condition on `AddRecipientUseCase`

## Motivation

<!-- Explain why this change was needed -->
These changes enable Order CRUD operations within the application's domain layer.

## How to test

1. Run unit test `npm run test`
2. Ensure that all tests pass

## Related issues

Closes #11 