### PR TITLE
[Feat] Implement order status change use cases

### DIFF
--- a/src/domain/cargo/application/repositories/orders-repository.ts
+++ b/src/domain/cargo/application/repositories/orders-repository.ts
@@ -3,5 +3,6 @@ import { Order } from '../../enterprise/entities/order'
 export abstract class OrdersRepository {
   abstract findById(id: string): Promise<Order | null>
   abstract create(order: Order): Promise<void>
+  abstract save(order: Order): Promise<void>
   abstract delete(order: Order): Promise<void>
 }

--- a/src/domain/cargo/application/use-cases/errors/invalid-order-status-error.ts
+++ b/src/domain/cargo/application/use-cases/errors/invalid-order-status-error.ts
@@ -2,9 +2,12 @@ import { UseCaseError } from '@/core/errors/use-case-error'
 import { OrderStatus } from '@/domain/cargo/enterprise/entities/order'
 
 export class InvalidOrderStatusError extends Error implements UseCaseError {
-  constructor(currentOrderStatus: OrderStatus) {
+  constructor(
+    currentOrderStatus: OrderStatus,
+    expectedOrderStatus: OrderStatus,
+  ) {
     super(
-      `Invalid order status. Current status is "${currentOrderStatus}" expected "${OrderStatus.ADDED}"`,
+      `Invalid order status. Current status is "${currentOrderStatus}" expected "${expectedOrderStatus}"`,
     )
   }
 }

--- a/src/domain/cargo/application/use-cases/errors/invalid-order-status-error.ts
+++ b/src/domain/cargo/application/use-cases/errors/invalid-order-status-error.ts
@@ -1,0 +1,10 @@
+import { UseCaseError } from '@/core/errors/use-case-error'
+import { OrderStatus } from '@/domain/cargo/enterprise/entities/order'
+
+export class InvalidOrderStatusError extends Error implements UseCaseError {
+  constructor(currentOrderStatus: OrderStatus) {
+    super(
+      `Invalid order status. Current status is "${currentOrderStatus}" expected "${OrderStatus.ADDED}"`,
+    )
+  }
+}

--- a/src/domain/cargo/application/use-cases/errors/unauthorized-error.ts
+++ b/src/domain/cargo/application/use-cases/errors/unauthorized-error.ts
@@ -1,0 +1,7 @@
+import { UseCaseError } from '@/core/errors/use-case-error'
+
+export class UnauthorizedError extends Error implements UseCaseError {
+  constructor() {
+    super('Unauthorized')
+  }
+}

--- a/src/domain/cargo/application/use-cases/order/mark-order-as-available.spec.ts
+++ b/src/domain/cargo/application/use-cases/order/mark-order-as-available.spec.ts
@@ -1,0 +1,61 @@
+import { InMemoryOrdersRepository } from 'test/respositories/in-memory-orders-repository'
+import { makeOrder } from 'test/factories/make-order'
+import { MarkOrderAsAvailableUseCase } from './mark-order-as-available'
+import { UnauthorizedError } from '../errors/unauthorized-error'
+import { OrderStatus } from '@/domain/cargo/enterprise/entities/order'
+import { InvalidOrderStatusError } from '../errors/invalid-order-status-error'
+
+let inMemoryOrdersRepository: InMemoryOrdersRepository
+let sut: MarkOrderAsAvailableUseCase
+
+describe('Mark Order as Available', () => {
+  beforeEach(() => {
+    inMemoryOrdersRepository = new InMemoryOrdersRepository()
+
+    sut = new MarkOrderAsAvailableUseCase(inMemoryOrdersRepository)
+  })
+
+  it('should be able to mark an order as available', async () => {
+    const order = makeOrder()
+
+    inMemoryOrdersRepository.items.push(order)
+
+    const result = await sut.execute({
+      orderId: order.id.toString(),
+      role: 'ADMIN',
+    })
+
+    expect(result.isRight()).toBe(true)
+    expect(result.value?.order.id).toEqual(order.id)
+  })
+
+  it('should not authorized to mark an order as available if the user is not admin', async () => {
+    const order = makeOrder()
+
+    inMemoryOrdersRepository.items.push(order)
+
+    const result = await sut.execute({
+      orderId: order.id.toString(),
+      role: 'DELIVERY_DRIVER',
+    })
+
+    expect(result.isLeft()).toBe(true)
+    expect(result.value).toBeInstanceOf(UnauthorizedError)
+  })
+
+  it('should not able to mark an order as available if the status order is not "added"', async () => {
+    const order = makeOrder({
+      status: OrderStatus.DELIVERED,
+    })
+
+    inMemoryOrdersRepository.items.push(order)
+
+    const result = await sut.execute({
+      orderId: order.id.toString(),
+      role: 'ADMIN',
+    })
+
+    expect(result.isLeft()).toBe(true)
+    expect(result.value).toBeInstanceOf(InvalidOrderStatusError)
+  })
+})

--- a/src/domain/cargo/application/use-cases/order/mark-order-as-available.ts
+++ b/src/domain/cargo/application/use-cases/order/mark-order-as-available.ts
@@ -1,0 +1,58 @@
+import { Either, left, right } from '@/core/either'
+import { OrdersRepository } from '../../repositories/orders-repository'
+import { ResourceNotFoundError } from '../errors/resource-not-found-error'
+import { UserRole } from '@/domain/cargo/enterprise/entities/user-role'
+import { Order, OrderStatus } from '@/domain/cargo/enterprise/entities/order'
+import { InvalidOrderStatusError } from '../errors/invalid-order-status-error'
+import { UnauthorizedError } from '../errors/unauthorized-error'
+
+interface MarkOrderAsAvailableUseCaseRequest {
+  orderId: string
+  role: string
+}
+
+type MarkOrderAsAvailableUseCaseResponse = Either<
+  UnauthorizedError | ResourceNotFoundError | InvalidOrderStatusError,
+  {
+    order: Order
+  }
+>
+
+export class MarkOrderAsAvailableUseCase {
+  constructor(private ordersRepository: OrdersRepository) {}
+
+  async execute({
+    orderId,
+    role,
+  }: MarkOrderAsAvailableUseCaseRequest): Promise<MarkOrderAsAvailableUseCaseResponse> {
+    const isValidRole = Object.values(UserRole).includes(role as UserRole)
+
+    if (!isValidRole) {
+      return left(new UnauthorizedError())
+    }
+
+    const validRole = role as UserRole
+
+    if (validRole !== UserRole.ADMIN) {
+      return left(new UnauthorizedError())
+    }
+
+    const order = await this.ordersRepository.findById(orderId)
+
+    if (!order) {
+      return left(new ResourceNotFoundError())
+    }
+
+    if (order.status !== OrderStatus.ADDED) {
+      return left(new InvalidOrderStatusError(order.status))
+    }
+
+    order.status = OrderStatus.AVAILABLE
+
+    await this.ordersRepository.save(order)
+
+    return right({
+      order,
+    })
+  }
+}

--- a/src/domain/cargo/application/use-cases/order/mark-order-as-available.ts
+++ b/src/domain/cargo/application/use-cases/order/mark-order-as-available.ts
@@ -44,7 +44,7 @@ export class MarkOrderAsAvailableUseCase {
     }
 
     if (order.status !== OrderStatus.ADDED) {
-      return left(new InvalidOrderStatusError(order.status))
+      return left(new InvalidOrderStatusError(order.status, OrderStatus.ADDED))
     }
 
     order.status = OrderStatus.AVAILABLE

--- a/src/domain/cargo/application/use-cases/order/pickup-order.spec.ts
+++ b/src/domain/cargo/application/use-cases/order/pickup-order.spec.ts
@@ -1,0 +1,89 @@
+import { InMemoryOrdersRepository } from 'test/respositories/in-memory-orders-repository'
+import { makeOrder } from 'test/factories/make-order'
+import { UnauthorizedError } from '../errors/unauthorized-error'
+import { OrderStatus } from '@/domain/cargo/enterprise/entities/order'
+import { InvalidOrderStatusError } from '../errors/invalid-order-status-error'
+import { PickupOrderUseCase } from './pickup-order'
+import { InMemoryDeliveryDriverRepository } from 'test/respositories/in-memory-delivery-driver-repository'
+import { makeDeliveryDriver } from 'test/factories/make-delivery-driver'
+
+let inMemoryOrdersRepository: InMemoryOrdersRepository
+let inMemoryDeliveryDriversRepository: InMemoryDeliveryDriverRepository
+let sut: PickupOrderUseCase
+
+describe('Pickup Order', () => {
+  beforeEach(() => {
+    inMemoryOrdersRepository = new InMemoryOrdersRepository()
+    inMemoryDeliveryDriversRepository = new InMemoryDeliveryDriverRepository()
+
+    sut = new PickupOrderUseCase(
+      inMemoryOrdersRepository,
+      inMemoryDeliveryDriversRepository,
+    )
+  })
+
+  it('should be able to pickup an order', async () => {
+    const order = makeOrder({
+      status: OrderStatus.AVAILABLE,
+    })
+
+    inMemoryOrdersRepository.items.push(order)
+
+    const deliveryDriver = makeDeliveryDriver()
+
+    inMemoryDeliveryDriversRepository.items.push(deliveryDriver)
+
+    const result = await sut.execute({
+      orderId: order.id.toString(),
+      deliveryDriverId: deliveryDriver.id.toString(),
+      role: 'ADMIN',
+    })
+
+    console.log(result)
+
+    expect(result.isRight()).toBe(true)
+    expect(result.value?.order.id).toEqual(order.id)
+  })
+
+  it('should not authorized to pickup an order if the user is not admin', async () => {
+    const order = makeOrder()
+
+    inMemoryOrdersRepository.items.push(order)
+
+    const deliveryDriver = makeDeliveryDriver()
+
+    inMemoryDeliveryDriversRepository.items.push(deliveryDriver)
+
+    const result = await sut.execute({
+      orderId: order.id.toString(),
+      deliveryDriverId: deliveryDriver.id.toString(),
+      role: 'DELIVERY_DRIVER',
+    })
+
+    expect(result.isLeft()).toBe(true)
+    expect(result.value).toBeInstanceOf(UnauthorizedError)
+  })
+
+  it('should not able to pickup an order if the status order is not "AVAILABLE"', async () => {
+    const order = makeOrder({
+      status: OrderStatus.ADDED,
+    })
+
+    inMemoryOrdersRepository.items.push(order)
+
+    const deliveryDriver = makeDeliveryDriver()
+
+    inMemoryDeliveryDriversRepository.items.push(deliveryDriver)
+
+    const result = await sut.execute({
+      orderId: order.id.toString(),
+      deliveryDriverId: deliveryDriver.id.toString(),
+      role: 'ADMIN',
+    })
+
+    console.log(result)
+
+    expect(result.isLeft()).toBe(true)
+    expect(result.value).toBeInstanceOf(InvalidOrderStatusError)
+  })
+})

--- a/src/domain/cargo/application/use-cases/order/pickup-order.ts
+++ b/src/domain/cargo/application/use-cases/order/pickup-order.ts
@@ -1,0 +1,73 @@
+import { Either, left, right } from '@/core/either'
+import { OrdersRepository } from '../../repositories/orders-repository'
+import { ResourceNotFoundError } from '../errors/resource-not-found-error'
+import { UserRole } from '@/domain/cargo/enterprise/entities/user-role'
+import { Order, OrderStatus } from '@/domain/cargo/enterprise/entities/order'
+import { InvalidOrderStatusError } from '../errors/invalid-order-status-error'
+import { UnauthorizedError } from '../errors/unauthorized-error'
+import { DeliveryDriverRepository } from '../../repositories/delivery-driver-repository'
+
+interface PickupOrderUseCaseRequest {
+  orderId: string
+  deliveryDriverId: string
+  role: string
+}
+
+type PickupOrderUseCaseResponse = Either<
+  UnauthorizedError | ResourceNotFoundError | InvalidOrderStatusError,
+  {
+    order: Order
+  }
+>
+
+export class PickupOrderUseCase {
+  constructor(
+    private ordersRepository: OrdersRepository,
+    private deliveryDriversRepository: DeliveryDriverRepository,
+  ) {}
+
+  async execute({
+    orderId,
+    deliveryDriverId,
+    role,
+  }: PickupOrderUseCaseRequest): Promise<PickupOrderUseCaseResponse> {
+    const isValidRole = Object.values(UserRole).includes(role as UserRole)
+
+    if (!isValidRole) {
+      return left(new UnauthorizedError())
+    }
+
+    const validRole = role as UserRole
+
+    if (validRole !== UserRole.ADMIN) {
+      return left(new UnauthorizedError())
+    }
+
+    const order = await this.ordersRepository.findById(orderId)
+
+    if (!order) {
+      return left(new ResourceNotFoundError())
+    }
+
+    const deliveryDriver =
+      await this.deliveryDriversRepository.findById(deliveryDriverId)
+
+    if (!deliveryDriver) {
+      return left(new ResourceNotFoundError())
+    }
+
+    if (order.status !== OrderStatus.AVAILABLE) {
+      return left(
+        new InvalidOrderStatusError(order.status, OrderStatus.AVAILABLE),
+      )
+    }
+
+    order.status = OrderStatus.PICKED_UP
+
+    await this.ordersRepository.save(order)
+
+    return right({
+      order,
+    })
+  }
+}

--- a/src/domain/cargo/application/use-cases/order/return-order.spec.ts
+++ b/src/domain/cargo/application/use-cases/order/return-order.spec.ts
@@ -1,0 +1,65 @@
+import { InMemoryOrdersRepository } from 'test/respositories/in-memory-orders-repository'
+import { makeOrder } from 'test/factories/make-order'
+import { UnauthorizedError } from '../errors/unauthorized-error'
+import { OrderStatus } from '@/domain/cargo/enterprise/entities/order'
+import { InvalidOrderStatusError } from '../errors/invalid-order-status-error'
+import { ReturnOrderUseCase } from './return-order'
+
+let inMemoryOrdersRepository: InMemoryOrdersRepository
+let sut: ReturnOrderUseCase
+
+describe('Return Order', () => {
+  beforeEach(() => {
+    inMemoryOrdersRepository = new InMemoryOrdersRepository()
+
+    sut = new ReturnOrderUseCase(inMemoryOrdersRepository)
+  })
+
+  it('should be able return an order', async () => {
+    const order = makeOrder({
+      status: OrderStatus.PICKED_UP,
+    })
+
+    inMemoryOrdersRepository.items.push(order)
+
+    const result = await sut.execute({
+      orderId: order.id.toString(),
+      role: 'ADMIN',
+    })
+
+    console.log(result)
+
+    expect(result.isRight()).toBe(true)
+    expect(result.value?.order.id).toEqual(order.id)
+  })
+
+  it('should not authorized to return an order if the user is not admin', async () => {
+    const order = makeOrder()
+
+    inMemoryOrdersRepository.items.push(order)
+
+    const result = await sut.execute({
+      orderId: order.id.toString(),
+      role: 'DELIVERY_DRIVER',
+    })
+
+    expect(result.isLeft()).toBe(true)
+    expect(result.value).toBeInstanceOf(UnauthorizedError)
+  })
+
+  it('should not able to return an order if the status order is not "PICKED_UP"', async () => {
+    const order = makeOrder({
+      status: OrderStatus.DELIVERED,
+    })
+
+    inMemoryOrdersRepository.items.push(order)
+
+    const result = await sut.execute({
+      orderId: order.id.toString(),
+      role: 'ADMIN',
+    })
+
+    expect(result.isLeft()).toBe(true)
+    expect(result.value).toBeInstanceOf(InvalidOrderStatusError)
+  })
+})

--- a/src/domain/cargo/application/use-cases/order/return-order.ts
+++ b/src/domain/cargo/application/use-cases/order/return-order.ts
@@ -1,0 +1,60 @@
+import { Either, left, right } from '@/core/either'
+import { OrdersRepository } from '../../repositories/orders-repository'
+import { ResourceNotFoundError } from '../errors/resource-not-found-error'
+import { UserRole } from '@/domain/cargo/enterprise/entities/user-role'
+import { Order, OrderStatus } from '@/domain/cargo/enterprise/entities/order'
+import { InvalidOrderStatusError } from '../errors/invalid-order-status-error'
+import { UnauthorizedError } from '../errors/unauthorized-error'
+
+interface ReturnOrderUseCaseRequest {
+  orderId: string
+  role: string
+}
+
+type ReturnOrderUseCaseResponse = Either<
+  UnauthorizedError | ResourceNotFoundError | InvalidOrderStatusError,
+  {
+    order: Order
+  }
+>
+
+export class ReturnOrderUseCase {
+  constructor(private ordersRepository: OrdersRepository) {}
+
+  async execute({
+    orderId,
+    role,
+  }: ReturnOrderUseCaseRequest): Promise<ReturnOrderUseCaseResponse> {
+    const isValidRole = Object.values(UserRole).includes(role as UserRole)
+
+    if (!isValidRole) {
+      return left(new UnauthorizedError())
+    }
+
+    const validRole = role as UserRole
+
+    if (validRole !== UserRole.ADMIN) {
+      return left(new UnauthorizedError())
+    }
+
+    const order = await this.ordersRepository.findById(orderId)
+
+    if (!order) {
+      return left(new ResourceNotFoundError())
+    }
+
+    if (order.status !== OrderStatus.PICKED_UP) {
+      return left(
+        new InvalidOrderStatusError(order.status, OrderStatus.PICKED_UP),
+      )
+    }
+
+    order.status = OrderStatus.RETURNED
+
+    await this.ordersRepository.save(order)
+
+    return right({
+      order,
+    })
+  }
+}

--- a/src/domain/cargo/enterprise/entities/order.ts
+++ b/src/domain/cargo/enterprise/entities/order.ts
@@ -3,7 +3,8 @@ import { Optional } from '../../../../core/types/optional'
 import { Entity } from '@/core/entities/entity'
 
 export enum OrderStatus {
-  WAITING = 'WAITING',
+  ADDED = 'ADDED',
+  AVAILABLE = 'AVAILABLE',
   PICKED_UP = 'PICKED_UP',
   DELIVERED = 'DELIVERED',
   RETURNED = 'RETURNED',
@@ -12,12 +13,41 @@ export enum OrderStatus {
 export interface OrderProps {
   deliveryDriverId?: UniqueEntityID
   recipientId: UniqueEntityID
-  status?: OrderStatus
+  status: OrderStatus
   createdAt: Date
   updatedAt?: Date
 }
 
 export class Order extends Entity<OrderProps> {
+  get deliveryDriverId() {
+    return this.props.deliveryDriverId
+  }
+
+  get recipientId() {
+    return this.props.recipientId
+  }
+
+  get status() {
+    return this.props.status
+  }
+
+  get createdAt() {
+    return this.props.createdAt
+  }
+
+  get updatedAt() {
+    return this.props.updatedAt
+  }
+
+  private touch() {
+    this.props.updatedAt = new Date()
+  }
+
+  set status(status: OrderStatus) {
+    this.props.status = status
+    this.touch()
+  }
+
   static create(
     props: Optional<OrderProps, 'status' | 'createdAt'>,
     id?: UniqueEntityID,
@@ -25,7 +55,7 @@ export class Order extends Entity<OrderProps> {
     const order = new Order(
       {
         ...props,
-        status: props.status ?? OrderStatus.WAITING,
+        status: props.status ?? OrderStatus.ADDED,
         createdAt: props.createdAt ?? new Date(),
       },
       id,

--- a/test/factories/make-order.ts
+++ b/test/factories/make-order.ts
@@ -1,9 +1,5 @@
 import { UniqueEntityID } from '@/core/entities/unique-entity-id'
-import {
-  Order,
-  OrderProps,
-  OrderStatus,
-} from '@/domain/cargo/enterprise/entities/order'
+import { Order, OrderProps } from '@/domain/cargo/enterprise/entities/order'
 
 export function makeOrder(
   override: Partial<OrderProps> = {},
@@ -13,7 +9,6 @@ export function makeOrder(
     {
       deliveryDriverId: new UniqueEntityID(),
       recipientId: new UniqueEntityID(),
-      status: OrderStatus.WAITING,
       ...override,
     },
     id,

--- a/test/respositories/in-memory-orders-repository.ts
+++ b/test/respositories/in-memory-orders-repository.ts
@@ -18,6 +18,12 @@ export class InMemoryOrdersRepository extends OrdersRepository {
     this.items.push(order)
   }
 
+  async save(order: Order): Promise<void> {
+    const itemIndex = this.items.findIndex((item) => item.id === order.id)
+
+    this.items[itemIndex] = order
+  }
+
   async delete(order: Order): Promise<void> {
     const itemIndex = this.items.findIndex((item) => item.id === order.id)
 


### PR DESCRIPTION
## Description

<!-- Write a short summary of what this PR does -->
This PR adds use cases to Order status changes

## Main changes

- Added `save` method to `OrdersRepository`
- Implemented `MarkOrderAsAvailable` use case
- Implemented `PickupOrder` use case
- Implemented `ReturnOrder` use case
- Tested use cases

## Motivation

<!-- Explain why this change was needed -->
These changes provide changes to the order status

## How to test

1. Run unit test: `npm run test`
2. Ensure that all tests pass

## Related issues

Closes #16 