### PR TITLE
[Feat] Implement notification domain

### DIFF
--- a/src/domain/notification/application/repositories/notifications-repository.ts
+++ b/src/domain/notification/application/repositories/notifications-repository.ts
@@ -1,0 +1,7 @@
+import { Notification } from '../../enterprise/entities/notification'
+
+export abstract class NotificationsRepository {
+  abstract findById(id: string): Promise<Notification | null>
+  abstract create(notification: Notification): Promise<void>
+  abstract save(notification: Notification): Promise<void>
+}

--- a/src/domain/notification/application/use-cases/read-notification.spec.ts
+++ b/src/domain/notification/application/use-cases/read-notification.spec.ts
@@ -1,0 +1,48 @@
+import { InMemoryNotificationsRepository } from 'test/respositories/in-memory-notifications-repository'
+import { makeNotification } from 'test/factories/make-notification'
+import { ReadNotificationUseCase } from './read-notification'
+import { UniqueEntityID } from '@/core/entities/unique-entity-id'
+import { NotAllowedError } from '@/core/errors/errors/not-allowed-error'
+
+let inMemoryNotificationsRepository: InMemoryNotificationsRepository
+let sut: ReadNotificationUseCase
+
+describe('Read Notification', () => {
+  beforeEach(() => {
+    inMemoryNotificationsRepository = new InMemoryNotificationsRepository()
+
+    sut = new ReadNotificationUseCase(inMemoryNotificationsRepository)
+  })
+
+  it('should be able to read a notification', async () => {
+    const notification = makeNotification({
+      recipientId: new UniqueEntityID('recipient-id'),
+    })
+
+    inMemoryNotificationsRepository.items.push(notification)
+
+    const result = await sut.execute({
+      recipientId: 'recipient-id',
+      notificationId: notification.id.toString(),
+    })
+
+    expect(result.isRight()).toBe(true)
+    expect(inMemoryNotificationsRepository.items[0].readedAt).toBeTruthy()
+  })
+
+  it('should not be able to read a notification from another recipient', async () => {
+    const notification = makeNotification({
+      recipientId: new UniqueEntityID('recipient-id'),
+    })
+
+    inMemoryNotificationsRepository.items.push(notification)
+
+    const result = await sut.execute({
+      recipientId: 'not-allowed-recipient-id',
+      notificationId: notification.id.toString(),
+    })
+
+    expect(result.isLeft()).toBe(true)
+    expect(result.value).toBeInstanceOf(NotAllowedError)
+  })
+})

--- a/src/domain/notification/application/use-cases/read-notification.ts
+++ b/src/domain/notification/application/use-cases/read-notification.ts
@@ -1,0 +1,45 @@
+import { Either, left, right } from '@/core/either'
+import { Notification } from '../../enterprise/entities/notification'
+import { NotificationsRepository } from '../repositories/notifications-repository'
+import { ResourceNotFoundError } from '@/core/errors/errors/resource-not-found-error'
+import { NotAllowedError } from '@/core/errors/errors/not-allowed-error'
+
+interface ReadNotificationUseCaseRequest {
+  recipientId: string
+  notificationId: string
+}
+
+type ReadNotificationUseCaseResponse = Either<
+  ResourceNotFoundError,
+  {
+    notification: Notification
+  }
+>
+
+export class ReadNotificationUseCase {
+  constructor(private notificationsRepository: NotificationsRepository) {}
+
+  async execute({
+    recipientId,
+    notificationId,
+  }: ReadNotificationUseCaseRequest): Promise<ReadNotificationUseCaseResponse> {
+    const notification =
+      await this.notificationsRepository.findById(notificationId)
+
+    if (!notification) {
+      return left(new ResourceNotFoundError())
+    }
+
+    if (notification.recipientId.toString() !== recipientId) {
+      return left(new NotAllowedError())
+    }
+
+    notification.read()
+
+    await this.notificationsRepository.save(notification)
+
+    return right({
+      notification,
+    })
+  }
+}

--- a/src/domain/notification/application/use-cases/send-notification.spec.ts
+++ b/src/domain/notification/application/use-cases/send-notification.spec.ts
@@ -1,0 +1,33 @@
+import { InMemoryNotificationsRepository } from 'test/respositories/in-memory-notifications-repository'
+import { SendNotificationUseCase } from './send-notification'
+import { makeNotification } from 'test/factories/make-notification'
+import { UniqueEntityID } from '@/core/entities/unique-entity-id'
+
+let inMemoryNotificationsRepository: InMemoryNotificationsRepository
+let sut: SendNotificationUseCase
+
+describe('Send Notification', () => {
+  beforeEach(() => {
+    inMemoryNotificationsRepository = new InMemoryNotificationsRepository()
+
+    sut = new SendNotificationUseCase(inMemoryNotificationsRepository)
+  })
+
+  it('should be able to send a notification', async () => {
+    const notification = makeNotification()
+
+    const result = await sut.execute({
+      recipientId: 'recipient-id',
+      title: notification.title,
+      content: notification.content,
+    })
+
+    expect(result.isRight()).toBe(true)
+    expect(inMemoryNotificationsRepository.items).toHaveLength(1)
+    expect(inMemoryNotificationsRepository.items[0]).toEqual(
+      expect.objectContaining({
+        recipientId: new UniqueEntityID('recipient-id'),
+      }),
+    )
+  })
+})

--- a/src/domain/notification/application/use-cases/send-notification.ts
+++ b/src/domain/notification/application/use-cases/send-notification.ts
@@ -1,0 +1,39 @@
+import { Either, right } from '@/core/either'
+import { Notification } from '../../enterprise/entities/notification'
+import { NotificationsRepository } from '../repositories/notifications-repository'
+import { UniqueEntityID } from '@/core/entities/unique-entity-id'
+
+interface SendNotificationUseCaseRequest {
+  recipientId: string
+  title: string
+  content: string
+}
+
+type SendNotificationUseCaseResponse = Either<
+  null,
+  {
+    notification: Notification
+  }
+>
+
+export class SendNotificationUseCase {
+  constructor(private notificationsRepository: NotificationsRepository) {}
+
+  async execute({
+    recipientId,
+    title,
+    content,
+  }: SendNotificationUseCaseRequest): Promise<SendNotificationUseCaseResponse> {
+    const notification = Notification.create({
+      recipientId: new UniqueEntityID(recipientId),
+      title,
+      content,
+    })
+
+    await this.notificationsRepository.create(notification)
+
+    return right({
+      notification,
+    })
+  }
+}

--- a/src/domain/notification/enterprise/entities/notification.ts
+++ b/src/domain/notification/enterprise/entities/notification.ts
@@ -1,0 +1,52 @@
+import { UniqueEntityID } from '@/core/entities/unique-entity-id'
+import { Optional } from '@/core/types/optional'
+import { Entity } from '@/core/entities/entity'
+
+export interface NotificationProps {
+  recipientId: UniqueEntityID
+  title: string
+  content: string
+  readedAt?: Date
+  createdAt: Date
+}
+
+export class Notification extends Entity<NotificationProps> {
+  get recipientId() {
+    return this.props.recipientId
+  }
+
+  get title() {
+    return this.props.title
+  }
+
+  get content() {
+    return this.props.content
+  }
+
+  get readedAt() {
+    return this.props.readedAt
+  }
+
+  get createdAt() {
+    return this.props.createdAt
+  }
+
+  read() {
+    this.props.readedAt = new Date()
+  }
+
+  static create(
+    props: Optional<NotificationProps, 'createdAt'>,
+    id?: UniqueEntityID,
+  ) {
+    const notification = new Notification(
+      {
+        ...props,
+        createdAt: props.createdAt ?? new Date(),
+      },
+      id,
+    )
+
+    return notification
+  }
+}

--- a/test/factories/make-notification.ts
+++ b/test/factories/make-notification.ts
@@ -1,0 +1,23 @@
+import { UniqueEntityID } from '@/core/entities/unique-entity-id'
+import {
+  Notification,
+  NotificationProps,
+} from '@/domain/notification/enterprise/entities/notification'
+import { faker } from '@faker-js/faker'
+
+export function makeNotification(
+  override: Partial<NotificationProps> = {},
+  id?: UniqueEntityID,
+) {
+  const notification = Notification.create(
+    {
+      recipientId: new UniqueEntityID(),
+      title: faker.lorem.sentence(),
+      content: faker.lorem.sentence(),
+      ...override,
+    },
+    id,
+  )
+
+  return notification
+}

--- a/test/respositories/in-memory-notifications-repository.ts
+++ b/test/respositories/in-memory-notifications-repository.ts
@@ -1,0 +1,28 @@
+import { NotificationsRepository } from '@/domain/notification/application/repositories/notifications-repository'
+import { Notification } from '@/domain/notification/enterprise/entities/notification'
+
+export class InMemoryNotificationsRepository extends NotificationsRepository {
+  public items: Notification[] = []
+
+  async findById(id: string) {
+    const notification = this.items.find((item) => item.id.toString() === id)
+
+    if (!notification) {
+      return null
+    }
+
+    return notification
+  }
+
+  async create(notification: Notification): Promise<void> {
+    this.items.push(notification)
+  }
+
+  async save(notification: Notification) {
+    const itemIndex = this.items.findIndex(
+      (item) => item.id === notification.id,
+    )
+
+    this.items[itemIndex] = notification
+  }
+}


### PR DESCRIPTION
## Description

<!-- Write a short summary of what this PR does -->
This PR adds the Notification domain.

## Main changes

- Implemented `Notification` entity
- Create `NotificationsRepository` contract
- Implemented `SendNotification` use case and test
- Implemented `ReadNotification` use case and test

## Motivation

<!-- Explain why this change was needed -->
These updates enable a notification service that can react to events in any other domain.

## How to test

1. Run unit tests on Notification domain: `npm run test src/domain/notification`
2. Ensure all tests pass

## Related issues

Closes #22 