### PR TITLE
[Feat] Implement domain events for notifications

### DIFF
--- a/src/core/entities/aggregate-root.ts
+++ b/src/core/entities/aggregate-root.ts
@@ -1,0 +1,20 @@
+import { DomainEvent } from '../events/domain-event'
+import { DomainEvents } from '../events/domain-events'
+import { Entity } from './entity'
+
+export abstract class AggregateRoot<Props> extends Entity<Props> {
+  private _domainEvents: DomainEvent[] = []
+
+  get domainEvents(): DomainEvent[] {
+    return this._domainEvents
+  }
+
+  protected addDomainEvent(domainEvent: DomainEvent): void {
+    this._domainEvents.push(domainEvent)
+    DomainEvents.markAggregateForDispatch(this)
+  }
+
+  public clearEvents() {
+    this._domainEvents = []
+  }
+}

--- a/src/core/entities/entity.ts
+++ b/src/core/entities/entity.ts
@@ -12,4 +12,16 @@ export class Entity<Props> {
     this.props = props
     this._id = id ?? new UniqueEntityID()
   }
+
+  public equals(entity: Entity<Props>) {
+    if (entity === this) {
+      return true
+    }
+
+    if (entity.id === this._id) {
+      return true
+    }
+
+    return false
+  }
 }

--- a/src/core/entities/unique-entity-id.ts
+++ b/src/core/entities/unique-entity-id.ts
@@ -10,4 +10,8 @@ export class UniqueEntityID {
   constructor(value?: string) {
     this.value = value ?? randomUUID()
   }
+
+  public equals(id: UniqueEntityID) {
+    return id.toString() === this.value
+  }
 }

--- a/src/core/events/domain-event.ts
+++ b/src/core/events/domain-event.ts
@@ -1,0 +1,6 @@
+import { UniqueEntityID } from '../entities/unique-entity-id'
+
+export interface DomainEvent {
+  ocurredAt: Date
+  getAggregateId(): UniqueEntityID
+}

--- a/src/core/events/domain-events.ts
+++ b/src/core/events/domain-events.ts
@@ -1,0 +1,87 @@
+import { AggregateRoot } from '../entities/aggregate-root'
+import { UniqueEntityID } from '../entities/unique-entity-id'
+import { DomainEvent } from './domain-event'
+
+type DomainEventCallback = (event: unknown) => void
+
+export class DomainEvents {
+  private static handlersMap: Record<string, DomainEventCallback[]> = {}
+  private static markedAggregates: AggregateRoot<unknown>[] = []
+
+  public static shouldRun = true
+
+  public static markAggregateForDispatch(aggregate: AggregateRoot<unknown>) {
+    const aggregateFound = !!this.findMarkedAggregateByID(aggregate.id)
+
+    if (!aggregateFound) {
+      this.markedAggregates.push(aggregate)
+    }
+  }
+
+  private static dispatchAggregateEvents(aggregate: AggregateRoot<unknown>) {
+    aggregate.domainEvents.forEach((event: DomainEvent) => this.dispatch(event))
+  }
+
+  private static removeAggregateFromMarkedDispatchList(
+    aggregate: AggregateRoot<unknown>,
+  ) {
+    const index = this.markedAggregates.findIndex((a) => a.equals(aggregate))
+
+    this.markedAggregates.splice(index, 1)
+  }
+
+  private static findMarkedAggregateByID(
+    id: UniqueEntityID,
+  ): AggregateRoot<unknown> | undefined {
+    return this.markedAggregates.find((aggregate) => aggregate.id.equals(id))
+  }
+
+  public static dispatchEventsForAggregate(id: UniqueEntityID) {
+    const aggregate = this.findMarkedAggregateByID(id)
+
+    if (aggregate) {
+      this.dispatchAggregateEvents(aggregate)
+      aggregate.clearEvents()
+      this.removeAggregateFromMarkedDispatchList(aggregate)
+    }
+  }
+
+  public static register(
+    callback: DomainEventCallback,
+    eventClassName: string,
+  ) {
+    const wasEventRegisteredBefore = eventClassName in this.handlersMap
+
+    if (!wasEventRegisteredBefore) {
+      this.handlersMap[eventClassName] = []
+    }
+
+    this.handlersMap[eventClassName].push(callback)
+  }
+
+  public static clearHandlers() {
+    this.handlersMap = {}
+  }
+
+  public static clearMarkedAggregates() {
+    this.markedAggregates = []
+  }
+
+  private static dispatch(event: DomainEvent) {
+    const eventClassName: string = event.constructor.name
+
+    const isEventRegistered = eventClassName in this.handlersMap
+
+    if (!this.shouldRun) {
+      return
+    }
+
+    if (isEventRegistered) {
+      const handlers = this.handlersMap[eventClassName]
+
+      for (const handler of handlers) {
+        handler(event)
+      }
+    }
+  }
+}

--- a/src/core/events/event-handler.ts
+++ b/src/core/events/event-handler.ts
@@ -1,0 +1,3 @@
+export interface EventHandler {
+  setupSubscriptions(): void
+}

--- a/src/domain/delivery/application/use-cases/order/pickup-order.ts
+++ b/src/domain/delivery/application/use-cases/order/pickup-order.ts
@@ -39,6 +39,8 @@ export class PickupOrderUseCase {
       return left(new ResourceNotFoundError())
     }
 
+    order.driverId = driver.id
+
     if (order.status !== OrderStatus.AVAILABLE) {
       return left(
         new InvalidOrderStatusError(order.status, OrderStatus.AVAILABLE),

--- a/src/domain/delivery/enterprise/entities/order.ts
+++ b/src/domain/delivery/enterprise/entities/order.ts
@@ -2,6 +2,7 @@ import { AggregateRoot } from '@/core/entities/aggregate-root'
 import { UniqueEntityID } from '@/core/entities/unique-entity-id'
 import { Optional } from '@/core/types/optional'
 import { OrderCreatedEvent } from '../events/order-created-event'
+import { OrderStatusChangedEvent } from '../events/order-status-changed-event'
 
 export enum OrderStatus {
   ADDED = 'ADDED',
@@ -12,7 +13,7 @@ export enum OrderStatus {
 }
 
 export interface OrderProps {
-  deliveryDriverId?: UniqueEntityID
+  driverId?: UniqueEntityID | null
   recipientId: UniqueEntityID
   status: OrderStatus
   createdAt: Date
@@ -20,8 +21,8 @@ export interface OrderProps {
 }
 
 export class Order extends AggregateRoot<OrderProps> {
-  get deliveryDriverId() {
-    return this.props.deliveryDriverId
+  get driverId(): UniqueEntityID | undefined | null {
+    return this.props.driverId
   }
 
   get recipientId() {
@@ -44,9 +45,16 @@ export class Order extends AggregateRoot<OrderProps> {
     this.props.updatedAt = new Date()
   }
 
+  set driverId(driverId: UniqueEntityID) {
+    this.props.driverId = driverId
+  }
+
   set status(status: OrderStatus) {
-    this.props.status = status
-    this.touch()
+    if (status !== this.props.status) {
+      this.props.status = status
+      this.touch()
+      this.addDomainEvent(new OrderStatusChangedEvent(this))
+    }
   }
 
   static create(

--- a/src/domain/delivery/enterprise/entities/order.ts
+++ b/src/domain/delivery/enterprise/entities/order.ts
@@ -1,6 +1,7 @@
-import { UniqueEntityID } from '../../../../core/entities/unique-entity-id'
-import { Optional } from '../../../../core/types/optional'
-import { Entity } from '@/core/entities/entity'
+import { AggregateRoot } from '@/core/entities/aggregate-root'
+import { UniqueEntityID } from '@/core/entities/unique-entity-id'
+import { Optional } from '@/core/types/optional'
+import { OrderCreatedEvent } from '../events/order-created-event'
 
 export enum OrderStatus {
   ADDED = 'ADDED',
@@ -18,7 +19,7 @@ export interface OrderProps {
   updatedAt?: Date
 }
 
-export class Order extends Entity<OrderProps> {
+export class Order extends AggregateRoot<OrderProps> {
   get deliveryDriverId() {
     return this.props.deliveryDriverId
   }
@@ -60,6 +61,12 @@ export class Order extends Entity<OrderProps> {
       },
       id,
     )
+
+    const isNewOrder = !id
+
+    if (isNewOrder) {
+      order.addDomainEvent(new OrderCreatedEvent(order))
+    }
 
     return order
   }

--- a/src/domain/delivery/enterprise/events/order-created-event.ts
+++ b/src/domain/delivery/enterprise/events/order-created-event.ts
@@ -1,0 +1,17 @@
+import { UniqueEntityID } from '@/core/entities/unique-entity-id'
+import { DomainEvent } from '@/core/events/domain-event'
+import { Order } from '../entities/order'
+
+export class OrderCreatedEvent implements DomainEvent {
+  public ocurredAt: Date
+  public order: Order
+
+  constructor(order: Order) {
+    this.ocurredAt = new Date()
+    this.order = order
+  }
+
+  getAggregateId(): UniqueEntityID {
+    return this.order.id
+  }
+}

--- a/src/domain/delivery/enterprise/events/order-status-changed-event.ts
+++ b/src/domain/delivery/enterprise/events/order-status-changed-event.ts
@@ -1,0 +1,17 @@
+import { UniqueEntityID } from '@/core/entities/unique-entity-id'
+import { DomainEvent } from '@/core/events/domain-event'
+import { Order } from '../entities/order'
+
+export class OrderStatusChangedEvent implements DomainEvent {
+  public ocurredAt: Date
+  public order: Order
+
+  constructor(order: Order) {
+    this.ocurredAt = new Date()
+    this.order = order
+  }
+
+  getAggregateId(): UniqueEntityID {
+    return this.order.id
+  }
+}

--- a/src/domain/notification/application/subscribers/on-order-created.spec.ts
+++ b/src/domain/notification/application/subscribers/on-order-created.spec.ts
@@ -1,0 +1,52 @@
+import { makeOrder } from 'test/factories/make-order'
+import { OnOrderCreated } from './on-order-created'
+import { InMemoryOrdersRepository } from 'test/respositories/in-memory-orders-repository'
+import { InMemoryRecipientRepository } from 'test/respositories/in-memory-recipients-repository'
+import {
+  SendNotificationUseCase,
+  SendNotificationUseCaseRequest,
+  SendNotificationUseCaseResponse,
+} from '../use-cases/send-notification'
+import { InMemoryNotificationsRepository } from 'test/respositories/in-memory-notifications-repository'
+import { makeRecipient } from 'test/factories/make-recipient'
+import { MockInstance } from 'vitest'
+import { waitFor } from 'test/utils/wait-for'
+
+let inMemoryOrdersRepository: InMemoryOrdersRepository
+let inMemoryRecipientsRepository: InMemoryRecipientRepository
+let inMemoryNotificationsRepository: InMemoryNotificationsRepository
+let sendNotificationUseCase: SendNotificationUseCase
+
+let sendNotificationExecutionSpy: MockInstance<
+  (
+    request: SendNotificationUseCaseRequest,
+  ) => Promise<SendNotificationUseCaseResponse>
+>
+
+describe('On Order Created', () => {
+  beforeEach(() => {
+    inMemoryOrdersRepository = new InMemoryOrdersRepository()
+    inMemoryRecipientsRepository = new InMemoryRecipientRepository()
+    inMemoryNotificationsRepository = new InMemoryNotificationsRepository()
+    sendNotificationUseCase = new SendNotificationUseCase(
+      inMemoryNotificationsRepository,
+    )
+
+    new OnOrderCreated(inMemoryRecipientsRepository, sendNotificationUseCase)
+
+    sendNotificationExecutionSpy = vi.spyOn(sendNotificationUseCase, 'execute')
+  })
+  it('should send a notification when an order is created', async () => {
+    const recipient = makeRecipient()
+    await inMemoryRecipientsRepository.create(recipient)
+
+    const order = makeOrder({
+      recipientId: recipient.id,
+    })
+    await inMemoryOrdersRepository.create(order)
+
+    await waitFor(() => {
+      expect(sendNotificationExecutionSpy).toHaveBeenCalled()
+    })
+  })
+})

--- a/src/domain/notification/application/subscribers/on-order-created.spec.ts
+++ b/src/domain/notification/application/subscribers/on-order-created.spec.ts
@@ -48,5 +48,6 @@ describe('On Order Created', () => {
     await waitFor(() => {
       expect(sendNotificationExecutionSpy).toHaveBeenCalled()
     })
+    expect(inMemoryNotificationsRepository.items).toHaveLength(1)
   })
 })

--- a/src/domain/notification/application/subscribers/on-order-created.ts
+++ b/src/domain/notification/application/subscribers/on-order-created.ts
@@ -29,7 +29,7 @@ export class OnOrderCreated implements EventHandler {
         recipientId: recipient.id.toString(),
         title: 'New Delivery Order',
         content:
-          'A new delivery order has been created for you. Open the app to view the details.',
+          'A new delivery order has been created for you. It will be available for assignment soon.',
       })
     }
   }

--- a/src/domain/notification/application/subscribers/on-order-created.ts
+++ b/src/domain/notification/application/subscribers/on-order-created.ts
@@ -1,0 +1,36 @@
+import { DomainEvents } from '@/core/events/domain-events'
+import { EventHandler } from '@/core/events/event-handler'
+import { RecipientsRepository } from '@/domain/delivery/application/repositories/recipients-repository'
+import { OrderCreatedEvent } from '@/domain/delivery/enterprise/events/order-created-event'
+import { SendNotificationUseCase } from '../use-cases/send-notification'
+
+export class OnOrderCreated implements EventHandler {
+  constructor(
+    private recipientsRepository: RecipientsRepository,
+    private sendNotification: SendNotificationUseCase,
+  ) {
+    this.setupSubscriptions()
+  }
+
+  setupSubscriptions(): void {
+    DomainEvents.register(
+      this.sendOrderCreatedNotification.bind(this) as (event: unknown) => void,
+      OrderCreatedEvent.name,
+    )
+  }
+
+  private async sendOrderCreatedNotification({ order }: OrderCreatedEvent) {
+    const recipient = await this.recipientsRepository.findById(
+      order.recipientId.toString(),
+    )
+
+    if (recipient) {
+      await this.sendNotification.execute({
+        recipientId: recipient.id.toString(),
+        title: 'New Delivery Order',
+        content:
+          'A new delivery order has been created for you. Open the app to view the details.',
+      })
+    }
+  }
+}

--- a/src/domain/notification/application/subscribers/on-order-status-changed.spec.ts
+++ b/src/domain/notification/application/subscribers/on-order-status-changed.spec.ts
@@ -1,0 +1,60 @@
+import { makeOrder } from 'test/factories/make-order'
+import { InMemoryOrdersRepository } from 'test/respositories/in-memory-orders-repository'
+import { InMemoryRecipientRepository } from 'test/respositories/in-memory-recipients-repository'
+import {
+  SendNotificationUseCase,
+  SendNotificationUseCaseRequest,
+  SendNotificationUseCaseResponse,
+} from '../use-cases/send-notification'
+import { InMemoryNotificationsRepository } from 'test/respositories/in-memory-notifications-repository'
+import { makeRecipient } from 'test/factories/make-recipient'
+import { MockInstance } from 'vitest'
+import { waitFor } from 'test/utils/wait-for'
+import { OrderStatus } from '@/domain/delivery/enterprise/entities/order'
+import { OnOrderStatusChanged } from './on-order-status-changed'
+
+let inMemoryOrdersRepository: InMemoryOrdersRepository
+let inMemoryRecipientsRepository: InMemoryRecipientRepository
+let inMemoryNotificationsRepository: InMemoryNotificationsRepository
+let sendNotificationUseCase: SendNotificationUseCase
+
+let sendNotificationExecutionSpy: MockInstance<
+  (
+    request: SendNotificationUseCaseRequest,
+  ) => Promise<SendNotificationUseCaseResponse>
+>
+
+describe('On Order Status Changed', () => {
+  beforeEach(() => {
+    inMemoryOrdersRepository = new InMemoryOrdersRepository()
+    inMemoryRecipientsRepository = new InMemoryRecipientRepository()
+    inMemoryNotificationsRepository = new InMemoryNotificationsRepository()
+    sendNotificationUseCase = new SendNotificationUseCase(
+      inMemoryNotificationsRepository,
+    )
+
+    new OnOrderStatusChanged(
+      inMemoryRecipientsRepository,
+      sendNotificationUseCase,
+    )
+
+    sendNotificationExecutionSpy = vi.spyOn(sendNotificationUseCase, 'execute')
+  })
+  it('should send a notification when an order status changed', async () => {
+    const recipient = makeRecipient()
+    await inMemoryRecipientsRepository.create(recipient)
+
+    const order = makeOrder({
+      recipientId: recipient.id,
+    })
+    await inMemoryOrdersRepository.create(order)
+
+    order.status = OrderStatus.AVAILABLE
+    await inMemoryOrdersRepository.save(order)
+
+    await waitFor(() => {
+      expect(sendNotificationExecutionSpy).toHaveBeenCalled()
+    })
+    expect(inMemoryNotificationsRepository.items).toHaveLength(1)
+  })
+})

--- a/src/domain/notification/application/subscribers/on-order-status-changed.ts
+++ b/src/domain/notification/application/subscribers/on-order-status-changed.ts
@@ -1,0 +1,80 @@
+import { DomainEvents } from '@/core/events/domain-events'
+import { EventHandler } from '@/core/events/event-handler'
+import { RecipientsRepository } from '@/domain/delivery/application/repositories/recipients-repository'
+import { SendNotificationUseCase } from '../use-cases/send-notification'
+import { OrderStatus } from '@/domain/delivery/enterprise/entities/order'
+import { OrderStatusChangedEvent } from '@/domain/delivery/enterprise/events/order-status-changed-event'
+
+export class OnOrderStatusChanged implements EventHandler {
+  constructor(
+    private recipientsRepository: RecipientsRepository,
+    private sendNotification: SendNotificationUseCase,
+  ) {
+    this.setupSubscriptions()
+  }
+
+  setupSubscriptions(): void {
+    DomainEvents.register(
+      this.sendOrderStatusChangedNotification.bind(this) as (
+        event: unknown,
+      ) => void,
+      OrderStatusChangedEvent.name,
+    )
+  }
+
+  private async sendOrderStatusChangedNotification({
+    order,
+  }: OrderStatusChangedEvent) {
+    const recipient = await this.recipientsRepository.findById(
+      order.recipientId.toString(),
+    )
+
+    if (recipient) {
+      switch (order.status) {
+        case OrderStatus.AVAILABLE: {
+          await this.sendNotification.execute({
+            recipientId: recipient.id.toString(),
+            title: 'Your Delivery Is Being Processed',
+            content:
+              "Your delivery is now in the queue to be picked up. We’ll notify you once it's on the way.",
+          })
+
+          break
+        }
+
+        case OrderStatus.PICKED_UP: {
+          await this.sendNotification.execute({
+            recipientId: recipient.id.toString(),
+            title: 'Your Delivery Is on the Way',
+            content:
+              'Your package has been picked up and is on its way to you. Be ready to receive it soon!',
+          })
+
+          break
+        }
+
+        case OrderStatus.DELIVERED: {
+          await this.sendNotification.execute({
+            recipientId: recipient.id.toString(),
+            title: 'Delivery Completed',
+            content:
+              'Your package has been successfully delivered. We hope everything arrived as expected!',
+          })
+
+          break
+        }
+
+        case OrderStatus.RETURNED: {
+          await this.sendNotification.execute({
+            recipientId: recipient.id.toString(),
+            title: 'Delivery Returned',
+            content:
+              'Your delivery could not be completed and was returned. Please contact support for more details.',
+          })
+
+          break
+        }
+      }
+    }
+  }
+}

--- a/src/domain/notification/application/use-cases/send-notification.ts
+++ b/src/domain/notification/application/use-cases/send-notification.ts
@@ -3,13 +3,13 @@ import { Notification } from '../../enterprise/entities/notification'
 import { NotificationsRepository } from '../repositories/notifications-repository'
 import { UniqueEntityID } from '@/core/entities/unique-entity-id'
 
-interface SendNotificationUseCaseRequest {
+export interface SendNotificationUseCaseRequest {
   recipientId: string
   title: string
   content: string
 }
 
-type SendNotificationUseCaseResponse = Either<
+export type SendNotificationUseCaseResponse = Either<
   null,
   {
     notification: Notification

--- a/test/respositories/in-memory-orders-repository.ts
+++ b/test/respositories/in-memory-orders-repository.ts
@@ -1,3 +1,4 @@
+import { DomainEvents } from '@/core/events/domain-events'
 import { OrdersRepository } from '@/domain/delivery/application/repositories/orders-repository'
 import { Order } from '@/domain/delivery/enterprise/entities/order'
 
@@ -16,6 +17,8 @@ export class InMemoryOrdersRepository extends OrdersRepository {
 
   async create(order: Order): Promise<void> {
     this.items.push(order)
+
+    DomainEvents.dispatchEventsForAggregate(order.id)
   }
 
   async save(order: Order): Promise<void> {

--- a/test/respositories/in-memory-orders-repository.ts
+++ b/test/respositories/in-memory-orders-repository.ts
@@ -25,6 +25,8 @@ export class InMemoryOrdersRepository extends OrdersRepository {
     const itemIndex = this.items.findIndex((item) => item.id === order.id)
 
     this.items[itemIndex] = order
+
+    DomainEvents.dispatchEventsForAggregate(order.id)
   }
 
   async delete(order: Order): Promise<void> {

--- a/test/utils/wait-for.ts
+++ b/test/utils/wait-for.ts
@@ -1,0 +1,31 @@
+/**
+ * This function loops through a function rerunning all assertions
+ * inside of it until it gets a truthy result.
+ *
+ * If the maximum duration is reached, it then rejects.
+ *
+ * @param expectations A function containing all tests assertions
+ * @param maxDuration Maximum wait time before rejecting
+ */
+export async function waitFor(
+  assertions: () => void,
+  maxDuration = 1000,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let elapsedTime = 0
+
+    const interval = setInterval(() => {
+      elapsedTime += 10
+
+      try {
+        assertions()
+        clearInterval(interval)
+        resolve()
+      } catch (err) {
+        if (elapsedTime >= maxDuration) {
+          reject(err)
+        }
+      }
+    }, 10)
+  })
+}


### PR DESCRIPTION
## Description

<!-- Write a short summary of what this PR does -->
This PR creates domain events to send notifications to recipients when a delivery order changes.

## Main changes

<!-- List key technical changes made -->
- Configured domain events and aggregate root
- Added an event and subscriber for order creation
- Added an event and subscriber for order status change
- Updated the Orders Repository to send events for aggregate on creation and save
- Tested notification creation when events are dispatched

## Motivation

<!-- Explain why this change was needed -->
These changes include notification emission to tell recipients about status changes to their orders.

## How to test

1. Run tests on the Notifications subscribers with `npm run test src/domain/notification/application/subscribers/`
2. Ensure that all tests pass

## Related issues

Closes #24 